### PR TITLE
Load Balancer Update

### DIFF
--- a/ci/iwyu/mappings.imp
+++ b/ci/iwyu/mappings.imp
@@ -97,6 +97,8 @@
 { "symbol": ["nlohmann::json", "private", "<nlohmann/json_fwd.hpp>", "public"] },
 
 # pybind11
+{ "include": [ "<pybind11/detail/common.h>", private, "<pybind11/pybind11.h>", "public" ] },
+
 { "symbol": ["pybind11", "private", "<pybind11/cast.h>", "public"] },
 { "symbol": ["pybind11", "private", "<pybind11/embed.h>", "public"] },
 { "symbol": ["pybind11", "private", "<pybind11/pybind11.h>", "public"] },

--- a/include/srf/node/sink_channel.hpp
+++ b/include/srf/node/sink_channel.hpp
@@ -68,4 +68,11 @@ void SinkChannel<T>::set_channel(std::shared_ptr<Channel<T>> channel)
     SinkChannelBase<T>::set_shared_channel(std::move(channel));
 }
 
+template <typename T>
+class SinkChannelReadable : public SinkChannel<T>
+{
+  public:
+    using SinkChannel<T>::egress;
+};
+
 }  // namespace srf::node

--- a/python/srf/_pysrf/include/pysrf/utils.hpp
+++ b/python/srf/_pysrf/include/pysrf/utils.hpp
@@ -20,7 +20,6 @@
 #include "pysrf/forward.hpp"  // IWYU pragma: keep
 
 #include <nlohmann/json_fwd.hpp>
-#include <pybind11/detail/common.h>
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>  // IWYU pragma: keep
 #include <pybind11/pytypes.h>

--- a/src/internal/segment/instance.cpp
+++ b/src/internal/segment/instance.cpp
@@ -219,7 +219,7 @@ void Instance::do_service_await_live()
         DVLOG(10) << info() << " awaiting on egress port " << name;
         runner->await_live();
     }
-    DVLOG(10) << info() << " join complete";
+    DVLOG(10) << info() << " await_live complete";
 }
 
 void Instance::do_service_await_join()
@@ -255,7 +255,7 @@ void Instance::do_service_await_join()
         DVLOG(10) << info() << " awaiting on egress port join to " << name;
         check(*runner);
     }
-    DVLOG(10) << info() << " join complete";
+    DVLOG(10) << info() << " await_join complete";
     if (first_exception)
     {
         LOG(ERROR) << "segment::Instance - an exception was caught while awaiting on one or more nodes - rethrowing";

--- a/src/tests/test_pipeline.cpp
+++ b/src/tests/test_pipeline.cpp
@@ -26,11 +26,9 @@
 #include "internal/system/system_provider.hpp"
 #include "internal/utils/collision_detector.hpp"
 
-#include "srf/channel/channel.hpp"
 #include "srf/channel/status.hpp"
 #include "srf/core/addresses.hpp"
 #include "srf/core/executor.hpp"
-#include "srf/core/thread_barrier.hpp"
 #include "srf/data/reusable_pool.hpp"
 #include "srf/engine/pipeline/ipipeline.hpp"
 #include "srf/node/queue.hpp"
@@ -51,7 +49,6 @@
 #include "srf/segment/object.hpp"
 #include "srf/utils/macros.hpp"
 
-#include <boost/fiber/barrier.hpp>
 #include <boost/fiber/fiber.hpp>
 #include <boost/fiber/operations.hpp>
 #include <boost/hana/if.hpp>
@@ -68,7 +65,6 @@
 #include <memory>
 #include <mutex>
 #include <ostream>
-#include <ratio>
 #include <stdexcept>
 #include <string>
 #include <system_error>


### PR DESCRIPTION
This PR updates the Load Balancer Manifold from a push based model requiring a node with multiple writers to a pull based one requiring zero runtime resources.

The behavior of the load-balancer is now improved, especially for work-loads for which the individual units of works are asymmetric with respect to compute time. If you had two segments, each assigned to a different class GPU say a T4 and an H100, then the new LB allows for the H100 to consume more work packets as it should complete work faster. The old behavior would blinding assign half the work to one segment and half to the other.

Relates to #157 