### PR TITLE
Update Task destructor logic to conform to the standard

### DIFF
--- a/cpp/mrc/include/mrc/coroutines/task.hpp
+++ b/cpp/mrc/include/mrc/coroutines/task.hpp
@@ -207,7 +207,7 @@ class [[nodiscard]] Task
 
     ~Task()
     {
-        if (m_coroutine != nullptr)
+        if (m_coroutine)
         {
             m_coroutine.destroy();
         }


### PR DESCRIPTION
Using gcc, the `if(m_coroutine != nullptr)` could trigger a compilation failure if the coroutine was returning a `std23::expected` with an error message of:

```
 error: satisfaction of atomic constraint ... depends on itself
```

Possibly relating to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99599

Another workaround was to use 
```
if(static_cast<std::coroutine_handle<>>(m_coroutine) != nullptr) {
```

but since `std::coroutine_handle` provides an [`operator bool()`](https://en.cppreference.com/w/cpp/coroutine/coroutine_handle/operator_bool), this is definitely the better way to go as seen by the cppreference.com examples.