### PR TITLE
Improved Task Lifecycle

### DIFF
--- a/cpp/mrc/include/mrc/coroutines/sync_wait.hpp
+++ b/cpp/mrc/include/mrc/coroutines/sync_wait.hpp
@@ -277,12 +277,7 @@ template <concepts::awaitable AwaitableT>
 auto sync_wait(AwaitableT&& a) -> decltype(auto)
 {
     detail::SyncWaitEvent e{};
-    // we force the lvalue ref path on the co_await operator of the AwaitableT
-    // on this path, the return value is maintained as part of the AwaitableT
-    // only after the AwaitableT is complete do we transfer the return value
-    // from the AwaitableT back to the user
-    AwaitableT ca = std::forward<AwaitableT>(a);
-    auto task     = detail::make_sync_wait_task(ca);
+    auto task = detail::make_sync_wait_task(std::forward<AwaitableT>(a));
     task.start(e);
     e.wait();
 

--- a/cpp/mrc/include/mrc/coroutines/when_all.hpp
+++ b/cpp/mrc/include/mrc/coroutines/when_all.hpp
@@ -482,7 +482,7 @@ class when_all_task
 
     ~when_all_task()
     {
-        if (m_coroutine != nullptr)
+        if (m_coroutine)
         {
             m_coroutine.destroy();
         }
@@ -523,7 +523,7 @@ class when_all_task
         }
         else
         {
-            return m_coroutine.promise().return_value();
+            return std::remove_reference_t<ReturnT>{std::move(m_coroutine.promise().return_value())};
         }
     }
 

--- a/cpp/mrc/tests/coroutines/test_task.cpp
+++ b/cpp/mrc/tests/coroutines/test_task.cpp
@@ -36,6 +36,7 @@
  * limitations under the License.
  */
 
+#include "mrc/core/std23_expected.hpp"
 #include "mrc/core/thread.hpp"
 #include "mrc/coroutines/ring_buffer.hpp"
 #include "mrc/coroutines/sync_wait.hpp"
@@ -115,4 +116,39 @@ TEST_F(TestCoroTask, RingBufferStressTest)
 
         coroutines::sync_wait(coroutines::when_all(source(), sink()));
     }
+}
+
+// this is our awaitable
+class AwaitableTaskProvider
+{
+  public:
+    struct Done
+    {};
+
+    AwaitableTaskProvider()
+    {
+        m_task_generator = []() -> coroutines::Task<std23::expected<int, Done>> { co_return{42}; };
+    }
+
+    auto operator co_await() -> decltype(auto)
+    {
+        return m_task_generator().operator co_await();
+    }
+
+  private:
+    std::function<coroutines::Task<std23::expected<int, Done>>()> m_task_generator;
+};
+
+TEST_F(TestCoroTask, AwaitableTaskProvider)
+{
+    auto expected = coroutines::sync_wait(AwaitableTaskProvider{});
+    EXPECT_EQ(*expected, 42);
+
+    auto task = []() -> coroutines::Task<void> {
+        auto expected = co_await AwaitableTaskProvider{};
+        EXPECT_EQ(*expected, 42);
+        co_return;
+    };
+
+    coroutines::sync_wait(task());
 }


### PR DESCRIPTION
This update allows the Task to transfer ownership of the coroutine handle to the `awaiter` returned by the Task's `operator co_await()` method.

Without this update [the linked test would fail on this line](https://github.com/nv-morpheus/MRC/compare/branch-23.01...ryanolson:task_lifecycle?expand=1#diff-abd2fa1b390dadc99ee7076e518e5ba9029bb0618c908af2ba54134c519f7277R135), because the Task is created in the Awaitable's `operator co_await()` method would not transfer ownership of the coroutines handle to the awaitable, so the Task's destructor would destroy the coroutine who's awaited the caller is awaiting on. 