### PR TITLE
Add ImmediateChannel

### DIFF
--- a/cpp/mrc/include/mrc/channel/v2/immediate_channel.hpp
+++ b/cpp/mrc/include/mrc/channel/v2/immediate_channel.hpp
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mrc/channel/status.hpp"
+#include "mrc/core/expected.hpp"
+#include "mrc/core/std23_expected.hpp"
+
+#include <glog/logging.h>
+
+#include <coroutine>
+#include <mutex>
+#include <utility>
+
+namespace mrc::channel::v2 {
+
+template <typename T>
+class ImmediateChannel
+{
+  public:
+    using mutex_type = std::mutex;
+
+    // mrc: hotpath
+    struct WriteOperation
+    {
+        WriteOperation(ImmediateChannel& parent, T&& data) : m_parent(parent), m_data(std::move(data)) {}
+
+        // writes always suspend
+        constexpr static auto await_ready() noexcept -> bool
+        {
+            return false;
+        }
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> std::coroutine_handle<>
+        {
+            auto lock            = std::unique_lock{m_parent.m_mutex};
+            m_awaiting_coroutine = awaiting_coroutine;
+
+            // if the channel was closed, resume immediate and throw an error in the await_resume method
+            if (m_parent.m_closed.load(std::memory_order::acquire)) [[unlikely]]
+            {
+                m_channel_closed = true;
+                return awaiting_coroutine;
+            }
+
+            // if there are no readers to resume, we insert ourself into the lifo queue of writers with data and yield
+            if (m_parent.m_read_waiters == nullptr)
+            {
+                m_next                   = m_parent.m_write_waiters;
+                m_parent.m_write_waiters = this;
+                return std::noop_coroutine();
+            }
+
+            // otherwise we prepare the reader for resumption
+            auto* reader            = m_parent.m_read_waiters;
+            m_parent.m_read_waiters = reader->m_next;
+            reader->m_data          = std::move(m_data);
+
+            // then we insert ourself at the end of the fifo queue of writers without data awaiting to be resumed
+            if (m_parent.m_write_resumers == nullptr)
+            {
+                m_parent.m_write_resumers = this;
+            }
+            else
+            {
+                // put current writer at the end of the fifo writer resumer list
+                auto* write_resumer = m_parent.m_write_resumers->m_next;
+                while (write_resumer->m_next != nullptr)
+                {
+                    write_resumer = write_resumer->m_next;
+                }
+                write_resumer->m_next = this;
+            }
+
+            // resume the reader via symmetric transfer
+            return reader->m_awaiting_coroutine;
+        }
+
+        auto await_resume() -> void
+        {
+            if (m_channel_closed) [[unlikely]]
+            {
+                auto error = Error::create(ErrorCode::ChannelClosed, "write failed on closed channel");
+                // LOG(ERROR) << error.value().message();
+                throw error.value();
+            }
+        }
+
+        ImmediateChannel& m_parent;
+        std::coroutine_handle<> m_awaiting_coroutine;
+        WriteOperation* m_next{nullptr};
+        bool m_channel_closed{false};
+        T m_data;
+        std::unique_lock<mutex_type> m_lock;
+    };
+
+    // mrc: hotpath
+    struct ReadOperation
+    {
+        bool await_ready()
+        {
+            m_lock = std::unique_lock(m_parent.m_mutex);
+            return m_parent.try_read_with_lock(this, m_lock);
+        }
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
+        {
+            DCHECK(m_lock.owns_lock());
+            auto lock = std::move(m_lock);
+
+            m_awaiting_coroutine    = awaiting_coroutine;
+            m_next                  = m_parent.m_read_waiters;
+            m_parent.m_read_waiters = this;
+        }
+
+        auto await_resume() noexcept -> std23::expected<T, Status>
+        {
+            if (m_channel_closed) [[unlikely]]
+            {
+                return std23::unexpected(Status::closed);
+            }
+
+            return {std::move(m_data)};
+        }
+
+        ImmediateChannel& m_parent;
+        std::coroutine_handle<> m_awaiting_coroutine;
+        ReadOperation* m_next{nullptr};
+        T m_data;
+        bool m_channel_closed{false};
+        std::unique_lock<mutex_type> m_lock;
+    };
+
+    [[nodiscard]] WriteOperation async_write(T&& data)
+    {
+        // mrc: hotpath
+        return WriteOperation{*this, std::move(data)};
+    }
+
+    [[nodiscard]] ReadOperation async_read()
+    {
+        // mrc: hotpath
+        return ReadOperation{*this};
+    }
+
+    void close()
+    {
+        // Only wake up waiters once.
+        if (m_closed.load(std::memory_order::acquire))
+        {
+            return;
+        }
+
+        std::unique_lock lock{m_mutex};
+        auto first_closer = !m_closed.exchange(true, std::memory_order::release);
+
+        // only the first caller of close should continue
+        if (first_closer)
+        {
+            // the readers flush the writers, then after all writers are finished,
+            // the readers will see the channel is closed and resume with the closed status
+            while (m_read_waiters != nullptr)
+            {
+                auto* to_resume = m_read_waiters;
+                m_read_waiters  = m_read_waiters->m_next;
+                lock.unlock();
+                to_resume->m_channel_closed = true;
+                to_resume->m_awaiting_coroutine.resume();
+                lock.lock();
+            }
+        }
+    }
+
+  private:
+    // mrc: hotpath
+    bool try_read_with_lock(ReadOperation* read_op, std::unique_lock<mutex_type>& lock)
+    {
+        // if there are any writers in any state, we will resume them
+        while (m_write_waiters != nullptr || m_write_resumers)
+        {
+            // first process any writer that still holds data
+            if (m_write_waiters != nullptr)
+            {
+                // pop writer off the lifo writers queue
+                auto resume_in_future    = m_write_waiters;
+                m_write_waiters          = m_write_waiters->m_next;
+                resume_in_future->m_next = nullptr;
+
+                // transfer the data object to this ReadOperation
+                read_op->m_data = std::move(resume_in_future->m_data);
+
+                // the writer we pulled off the writers queue we push to the end of waiters fifo queue
+                if (m_write_resumers == nullptr)
+                {
+                    m_write_resumers = resume_in_future;
+                }
+                else
+                {
+                    auto last = m_write_resumers;
+                    while (last->m_next != nullptr)
+                    {
+                        last = last->m_next;
+                    }
+                    last->m_next = resume_in_future;
+                }
+
+                lock.unlock();
+                return true;
+            }
+
+            // there were no writers with data, so there must be at least one waiting to be resumed
+            DCHECK(m_write_resumers != nullptr);
+
+            // pop off the first resumer
+            auto* to_resume  = m_write_resumers;
+            m_write_resumers = to_resume->m_next;
+
+            // resume the writer
+            lock.unlock();
+            to_resume->m_awaiting_coroutine.resume();
+            lock.lock();
+        }
+
+        // if there are no readers and the channel is closed, we should resume immediately
+        if (m_closed.load(std::memory_order::acquire)) [[unlikely]]
+        {
+            read_op->m_channel_closed = true;
+            lock.unlock();
+            return true;
+        }
+
+        // there are no writers present and the channel is still open ==> this reader must suspend
+        // the await_suspend method is responsible for unlocking
+        return false;
+    }
+
+    mutex_type m_mutex;
+    WriteOperation* m_write_waiters{nullptr};
+    WriteOperation* m_write_resumers{nullptr};
+    ReadOperation* m_read_waiters{nullptr};
+    std::atomic<bool> m_closed{false};
+};
+
+}  // namespace mrc::channel::v2

--- a/cpp/mrc/include/mrc/channel/v2/immediate_channel.hpp
+++ b/cpp/mrc/include/mrc/channel/v2/immediate_channel.hpp
@@ -18,8 +18,8 @@
 #pragma once
 
 #include "mrc/channel/status.hpp"
+#include "mrc/core/error.hpp"
 #include "mrc/core/expected.hpp"
-#include "mrc/core/std23_expected.hpp"
 
 #include <glog/logging.h>
 
@@ -79,7 +79,7 @@ class ImmediateChannel
             else
             {
                 // put current writer at the end of the fifo writer resumer list
-                auto* write_resumer = m_parent.m_write_resumers->m_next;
+                auto* write_resumer = m_parent.m_write_resumers;
                 while (write_resumer->m_next != nullptr)
                 {
                     write_resumer = write_resumer->m_next;
@@ -128,11 +128,11 @@ class ImmediateChannel
             m_parent.m_read_waiters = this;
         }
 
-        auto await_resume() noexcept -> std23::expected<T, Status>
+        auto await_resume() noexcept -> mrc::expected<T, Status>
         {
             if (m_channel_closed) [[unlikely]]
             {
-                return std23::unexpected(Status::closed);
+                return mrc::unexpected(Status::closed);
             }
 
             return {std::move(m_data)};

--- a/cpp/mrc/include/mrc/core/error.hpp
+++ b/cpp/mrc/include/mrc/core/error.hpp
@@ -17,22 +17,18 @@
 
 #pragma once
 
-#include "mrc/core/std23_expected.hpp"  // IWYU pragma: export
+#include "mrc/core/expected.hpp"  // IWYU pragma: export
 #include "mrc/utils/macros.hpp"
 #include "mrc/utils/string_utils.hpp"  // IWYU pragma: export
 
-namespace mrc::internal {
+namespace mrc {
 
 enum class ErrorCode
 {
     Internal,
     Fatal,
+    ChannelClosed,
 };
-
-class Error;
-
-// todo(#219) - update tidy to allow the following typedef
-using UnexpectedError = std23::unexpected<Error>;  // NOLINT
 
 class Error final : public std::exception
 {
@@ -42,9 +38,9 @@ class Error final : public std::exception
 
   public:
     template <typename... ArgsT>
-    static UnexpectedError create(ArgsT&&... args)
+    static auto create(ArgsT&&... args) -> decltype(auto)
     {
-        return UnexpectedError(Error(std::forward<ArgsT>(args)...));
+        return unexpected(Error(std::forward<ArgsT>(args)...));
     }
 
     DEFAULT_MOVEABILITY(Error);
@@ -70,7 +66,7 @@ class Error final : public std::exception
 };
 
 template <typename T = void>
-using Expected = std23::expected<T, Error>;  // NOLINT
+using Expected = expected<T, Error>;  // NOLINT
 
 #define MRC_CHECK(condition)                                                  \
     if (!(condition))                                                         \
@@ -92,4 +88,4 @@ using Expected = std23::expected<T, Error>;  // NOLINT
         throw expected.error();                                       \
     }
 
-}  // namespace mrc::internal
+}  // namespace mrc

--- a/cpp/mrc/include/mrc/core/expected.hpp
+++ b/cpp/mrc/include/mrc/core/expected.hpp
@@ -55,7 +55,7 @@
 #include <utility>
 #include <variant>
 
-namespace std23 {
+namespace mrc {
 
 // clang-format off
 // NOLINTBEGIN(*)
@@ -1478,4 +1478,4 @@ class expected<void, E> {
 // NOLINTEND(*)
 // clang-format on
 
-}  // namespace std23
+}  // namespace mrc

--- a/cpp/mrc/include/mrc/coroutines/ring_buffer.hpp
+++ b/cpp/mrc/include/mrc/coroutines/ring_buffer.hpp
@@ -38,7 +38,7 @@
 
 #pragma once
 
-#include "mrc/core/std23_expected.hpp"
+#include "mrc/core/expected.hpp"
 #include "mrc/coroutines/schedule_policy.hpp"
 #include "mrc/coroutines/thread_local_context.hpp"
 #include "mrc/coroutines/thread_pool.hpp"
@@ -243,13 +243,13 @@ class RingBuffer
         /**
          * @return The consumed element or std::nullopt if the read has failed.
          */
-        auto await_resume() -> std23::expected<ElementT, RingBufferOpStatus>
+        auto await_resume() -> mrc::expected<ElementT, RingBufferOpStatus>
         {
             ThreadLocalContext::resume_thread_local_context();
 
             if (m_stopped)
             {
-                return std23::unexpected<RingBufferOpStatus>(RingBufferOpStatus::Stopped);
+                return mrc::unexpected<RingBufferOpStatus>(RingBufferOpStatus::Stopped);
             }
 
             return std::move(m_e);

--- a/cpp/mrc/src/internal/control_plane/client.hpp
+++ b/cpp/mrc/src/internal/control_plane/client.hpp
@@ -18,12 +18,12 @@
 #pragma once
 
 #include "internal/control_plane/client/instance.hpp"  // IWYU pragma: keep
-#include "internal/expected.hpp"
 #include "internal/grpc/client_streaming.hpp"
 #include "internal/grpc/stream_writer.hpp"
 #include "internal/resources/partition_resources_base.hpp"
 #include "internal/service.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/node/source_channel.hpp"
 #include "mrc/protos/architect.grpc.pb.h"
 #include "mrc/protos/architect.pb.h"

--- a/cpp/mrc/src/internal/control_plane/client/connections_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/connections_manager.cpp
@@ -19,12 +19,12 @@
 
 #include "internal/control_plane/client.hpp"
 #include "internal/control_plane/client/instance.hpp"
-#include "internal/expected.hpp"
 #include "internal/runnable/resources.hpp"
 #include "internal/ucx/resources.hpp"
 #include "internal/ucx/worker.hpp"
 #include "internal/utils/contains.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/core/task_queue.hpp"
 #include "mrc/protos/architect.pb.h"
 

--- a/cpp/mrc/src/internal/control_plane/client/state_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/state_manager.cpp
@@ -18,9 +18,9 @@
 #include "internal/control_plane/client/state_manager.hpp"
 
 #include "internal/control_plane/client.hpp"
-#include "internal/expected.hpp"
 #include "internal/runnable/resources.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/node/edge_builder.hpp"
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/node/source_channel.hpp"

--- a/cpp/mrc/src/internal/control_plane/client/subscription_service.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/subscription_service.cpp
@@ -19,10 +19,10 @@
 
 #include "internal/control_plane/client.hpp"
 #include "internal/control_plane/client/instance.hpp"
-#include "internal/expected.hpp"
 #include "internal/service.hpp"
 #include "internal/utils/contains.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/protos/architect.pb.h"
 
 #include <boost/fiber/future/promise.hpp>

--- a/cpp/mrc/src/internal/control_plane/proto_helpers.hpp
+++ b/cpp/mrc/src/internal/control_plane/proto_helpers.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "internal/expected.hpp"
+#include "mrc/core/error.hpp"
 
 #include <google/protobuf/any.pb.h>
 

--- a/cpp/mrc/src/internal/control_plane/server.cpp
+++ b/cpp/mrc/src/internal/control_plane/server.cpp
@@ -309,11 +309,11 @@ void Server::do_handle_event(event_t&& event)
             DVLOG(10) << "event.ok failed; close stream";
             drop_stream(event.stream);
         }
-    } catch (const std23::bad_expected_access<Error>& e)
+    } catch (const mrc::bad_expected_access<Error>& e)
     {
         LOG(ERROR) << "bad_expected_access: " << e.error().message();
         on_fatal_exception();
-    } catch (const UnexpectedError& e)
+    } catch (const mrc::unexpected<Error>& e)
     {
         LOG(ERROR) << "unexpected: " << e.value().message();
         on_fatal_exception();

--- a/cpp/mrc/src/internal/control_plane/server.hpp
+++ b/cpp/mrc/src/internal/control_plane/server.hpp
@@ -18,11 +18,11 @@
 #pragma once
 
 #include "internal/control_plane/server/connection_manager.hpp"
-#include "internal/expected.hpp"
 #include "internal/grpc/server.hpp"
 #include "internal/grpc/server_streaming.hpp"
 #include "internal/service.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/node/queue.hpp"
 #include "mrc/protos/architect.grpc.pb.h"
 

--- a/cpp/mrc/src/internal/control_plane/server/connection_manager.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/connection_manager.hpp
@@ -18,9 +18,9 @@
 #pragma once
 
 #include "internal/control_plane/server/versioned_issuer.hpp"
-#include "internal/expected.hpp"
 #include "internal/grpc/server_streaming.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/types.hpp"
 
 #include <cstddef>

--- a/cpp/mrc/src/internal/control_plane/server/subscription_manager.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/subscription_manager.hpp
@@ -19,8 +19,8 @@
 
 #include "internal/control_plane/server/tagged_issuer.hpp"
 #include "internal/control_plane/server/versioned_issuer.hpp"
-#include "internal/expected.hpp"
 
+#include "mrc/core/error.hpp"
 #include "mrc/types.hpp"
 
 #include <cstdint>

--- a/cpp/mrc/src/tests/test_expected.cpp
+++ b/cpp/mrc/src/tests/test_expected.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "internal/expected.hpp"
+#include "mrc/core/error.hpp"
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
@@ -26,7 +26,6 @@
 #include <utility>
 
 using namespace mrc;
-using namespace mrc::internal;
 
 class TestExpected : public ::testing::Test
 {};

--- a/cpp/mrc/tests/CMakeLists.txt
+++ b/cpp/mrc/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 # Keep all source files sorted!!!
 add_executable(test_mrc
+  channels/test_immediate_channel.cpp
   coroutines/test_event.cpp
   coroutines/test_latch.cpp
   coroutines/test_ring_buffer.cpp

--- a/cpp/mrc/tests/channels/test_immediate_channel.cpp
+++ b/cpp/mrc/tests/channels/test_immediate_channel.cpp
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mrc/channel/v2/immediate_channel.hpp"
+#include "mrc/coroutines/sync_wait.hpp"
+#include "mrc/coroutines/task.hpp"
+#include "mrc/coroutines/when_all.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+using namespace mrc;
+using namespace mrc::channel;
+using namespace mrc::channel::v2;
+
+class TestChannelV2 : public ::testing::Test
+{
+  protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    ImmediateChannel<int> m_channel;
+
+    coroutines::Task<void> int_writer(int iterations)
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            co_await m_channel.async_write(std::move(i));
+        }
+        m_channel.close();
+        co_return;
+    }
+
+    coroutines::Task<void> int_reader(int iterations)
+    {
+        int i = 0;
+        while (true)
+        {
+            auto data = co_await m_channel.async_read();
+            if (!data)
+            {
+                break;
+            }
+            i++;
+        }
+        EXPECT_EQ(i, iterations);
+        co_return;
+    }
+};
+
+TEST_F(TestChannelV2, ChannelClosed)
+{
+    ImmediateChannel<int> channel;
+    channel.close();
+
+    auto test = [&]() -> coroutines::Task<void> {
+        // write should throw
+        EXPECT_ANY_THROW(co_await channel.async_write(42));
+
+        // read should return unexpected
+        auto data = co_await channel.async_read();
+        EXPECT_FALSE(data);
+
+        // task throws
+        co_await channel.async_write(42);
+        co_return;
+    };
+
+    EXPECT_ANY_THROW(coroutines::sync_wait(test()));
+}
+
+TEST_F(TestChannelV2, SingleWriterSingleReader)
+{
+    coroutines::sync_wait(coroutines::when_all(int_writer(3), int_reader(3)));
+}
+
+TEST_F(TestChannelV2, Readerx1_Writer_x1)
+{
+    coroutines::sync_wait(coroutines::when_all(int_reader(3), int_writer(3)));
+}
+
+TEST_F(TestChannelV2, Readerx2_Writer_x1)
+{
+    coroutines::sync_wait(coroutines::when_all(int_reader(2), int_reader(1), int_writer(3)));
+}
+
+TEST_F(TestChannelV2, Readerx3_Writer_x1)
+{
+    coroutines::sync_wait(coroutines::when_all(int_reader(1), int_reader(1), int_reader(1), int_writer(3)));
+}
+
+TEST_F(TestChannelV2, Readerx4_Writer_x1)
+{
+    // reader are a lifo, so the first reader in the task list will not get a data entry
+    coroutines::sync_wait(
+        coroutines::when_all(int_reader(0), int_reader(1), int_reader(1), int_reader(1), int_writer(3)));
+}
+
+TEST_F(TestChannelV2, Readerx3_Writer_x1_Reader_x1)
+{
+    coroutines::sync_wait(
+        coroutines::when_all(int_reader(1), int_reader(1), int_reader(1), int_writer(3), int_reader(0)));
+}
+
+TEST_F(TestChannelV2, Writer_2_Reader_x2)
+{
+    coroutines::sync_wait(coroutines::when_all(int_writer(2), int_writer(2), int_reader(4), int_reader(0)));
+}


### PR DESCRIPTION
ImmediateChannel shall:
  - Writes will suspend if there are no awaiting Readers
  - Reads will suspend if there are no awaiting Writers
  - Awaiting writers holding data are always processed first
  - Suspended writers are put in a FIFO resume linked-list after their data has been consumed
  - If no incoming (writer) data is available, writers are resumed in FIFO ordering from the resume queue
  - The execution context is held by the writer until there are no remaining writers to resume; in which case, forward progress can only be resumed by the execution context of a new upstream write event.
  - Back pressure is managed by transferring the execution context downstream, pausing upstream progress
  - Does not enable pipeline concurrency as the execution context is transferred.