### PR TITLE
rename morpheus_utils_configure_boost_* to use new utilities naming

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,9 +30,7 @@ rapids_find_package(CUDAToolkit
 
 # Boost
 # =====
-# - Use static linking to avoid issues with system-wide installations of Boost.
-# - Use numa=on to ensure the numa component of fiber gets built
-morpheus_utils_configure_boost_boost_cmake()
+morpheus_utils_configure_boost()
 
 # UCX
 # ===


### PR DESCRIPTION
Required to fix a breaking change in https://github.com/nv-morpheus/utilities/pull/5