### PR TITLE
Fix function wrappers with `functools.partial`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
+      run_package_conda: ${{ startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-221130
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-base-221130
     secrets:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ startsWith(github.ref_name, 'pull-request/') }}
+      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-221130
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-base-221130
     secrets:

--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -97,7 +97,12 @@ if [[ "${CONDA_COMMAND}" == "mambabuild" || "${CONDA_COMMAND}" == "build" ]]; th
 fi
 
 # Choose default variants
-CONDA_ARGS_ARRAY+=("--variants" "{python: 3.8}")
+if hasArg quick; then
+   # For quick build, just do most recent version of rapids
+   CONDA_ARGS_ARRAY+=("--variants" "{python: 3.8, rapids_version: 22.10}")
+else
+   CONDA_ARGS_ARRAY+=("--variants" "{python: 3.8}")
+fi
 
 # And default channels
 CONDA_ARGS_ARRAY+=("-c" "rapidsai" "-c" "nvidia" "-c" "conda-forge" "-c" "main")

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -18,8 +18,23 @@ set -e
 
 source ${WORKSPACE}/ci/scripts/github/common.sh
 
-update_conda_env
+# Its important that we are in the base environment for the build
+rapids-logger "Ensuring base environnment is active"
+
+# update_conda_env
+
+while [[ "${CONDA_SHLVL:-0}" -gt 1 ]]; do
+   echo "Deactivating"
+   conda deactivate
+done
+
+if [[ "${CONDA_DEFAULT_ENV}" != "base" ]]; then
+   echo "Activating base"
+   conda activate base
+fi
+
+conda info
 
 rapids-logger "Building Conda Package"
 
-${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh upload
+${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -19,7 +19,7 @@ set -e
 source ${WORKSPACE}/ci/scripts/github/common.sh
 
 # Its important that we are in the base environment for the build
-rapids-logger "Ensuring base environnment is active"
+rapids-logger "Activating Base Conda Environment"
 
 # update_conda_env
 
@@ -33,8 +33,10 @@ if [[ "${CONDA_DEFAULT_ENV}" != "base" ]]; then
    conda activate base
 fi
 
+# Print the info just to be sure base is active
 conda info
 
 rapids-logger "Building Conda Package"
 
+# Run the conda build and upload
 ${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -21,15 +21,15 @@ source ${WORKSPACE}/ci/scripts/github/common.sh
 # Its important that we are in the base environment for the build
 rapids-logger "Activating Base Conda Environment"
 
-# update_conda_env
-
+# Deactivate any extra environments (There can be a few on the stack)
 while [[ "${CONDA_SHLVL:-0}" -gt 1 ]]; do
-   echo "Deactivating"
+   echo "Deactivating conda environment ${CONDA_DEFAULT_ENV}"
    conda deactivate
 done
 
+# Ensure at least base is activated
 if [[ "${CONDA_DEFAULT_ENV}" != "base" ]]; then
-   echo "Activating base"
+   echo "Activating base conda environment"
    conda activate base
 fi
 
@@ -39,4 +39,4 @@ conda info
 rapids-logger "Building Conda Package"
 
 # Run the conda build and upload
-${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh
+${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh upload

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/src/utilities/function_wrappers.cpp
+++ b/python/mrc/_pymrc/src/utilities/function_wrappers.cpp
@@ -20,6 +20,7 @@
 #include "pymrc/utilities/object_wrappers.hpp"
 
 #include <pybind11/detail/internals.h>
+
 #include <cstddef>
 
 namespace mrc::pymrc {

--- a/python/mrc/_pymrc/src/utilities/function_wrappers.cpp
+++ b/python/mrc/_pymrc/src/utilities/function_wrappers.cpp
@@ -20,6 +20,7 @@
 #include "pymrc/utilities/object_wrappers.hpp"
 
 #include <pybind11/detail/internals.h>
+#include <cstddef>
 
 namespace mrc::pymrc {
 

--- a/python/tests/test_node.py
+++ b/python/tests/test_node.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import functools
+
 import pytest
 
 import mrc

--- a/python/tests/test_node.py
+++ b/python/tests/test_node.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import pytest
 
 import mrc
@@ -347,8 +348,9 @@ def test_sink_function_options(single_segment_pipeline,
     assert on_completed_count == (1 if use_on_completed else 0)
 
 
+@pytest.mark.parametrize("use_partial", [True, False])
 @pytest.mark.parametrize("node_type", ["runnable", "component"])
-def test_node_function_unpacking(single_segment_pipeline, node_type: str):
+def test_node_function_unpacking(single_segment_pipeline, node_type: str, use_partial: bool):
 
     is_component = node_type == "component"
 
@@ -356,19 +358,27 @@ def test_node_function_unpacking(single_segment_pipeline, node_type: str):
     on_error_count = 0
     on_completed_count = 0
 
+    max_emissions = 5
+
     def segment_init(seg: mrc.Builder):
 
         def create_source():
             for s_idx, s in enumerate(["one", "two", "three"]):
                 for i in range(s_idx, 5):
-                    yield s, i + s_idx
+                    if (use_partial):
+                        yield s, i + s_idx
+                    else:
+                        yield s, i + s_idx, max_emissions
 
         source = seg.make_source("source", create_source())
 
-        def node_on_next(s: str, i: int):
+        def node_on_next(s: str, i: int, max_e: int):
 
             # Double both values
-            return s + s, i + i
+            return s + s, i + i, max_e
+
+        if (use_partial):
+            node_on_next = functools.partial(node_on_next, max_e=max_emissions)
 
         if (is_component):
             node = seg.make_node_component("node", ops.map(node_on_next))
@@ -377,13 +387,16 @@ def test_node_function_unpacking(single_segment_pipeline, node_type: str):
 
         seg.make_edge(source, node)
 
-        def on_next(s: str, i: int):
+        def on_next(s: str, i: int, max_e: int):
             nonlocal on_next_values
 
             if (s not in on_next_values):
                 on_next_values[s] = []
 
             on_next_values[s].append(i)
+
+            # Make sure this value is set
+            assert max_emissions == max_e
 
         def on_error(e):
             nonlocal on_error_count
@@ -411,8 +424,9 @@ def test_node_function_unpacking(single_segment_pipeline, node_type: str):
     assert on_completed_count == 1
 
 
+@pytest.mark.parametrize("use_partial", [True, False])
 @pytest.mark.parametrize("node_type", ["runnable", "component"])
-def test_sink_function_unpacking(single_segment_pipeline, node_type: str):
+def test_sink_function_unpacking(single_segment_pipeline, node_type: str, use_partial: bool):
 
     is_component = node_type == "component"
 
@@ -420,22 +434,30 @@ def test_sink_function_unpacking(single_segment_pipeline, node_type: str):
     on_error_count = 0
     on_completed_count = 0
 
+    max_emissions = 5
+
     def segment_init(seg: mrc.Builder):
 
         def create_source():
             for s_idx, s in enumerate(["one", "two", "three"]):
-                for i in range(s_idx, 5):
-                    yield s, i + s_idx
+                for i in range(s_idx, max_emissions):
+                    if (use_partial):
+                        yield s, i + s_idx
+                    else:
+                        yield s, i + s_idx, max_emissions
 
         source = seg.make_source("source", create_source())
 
-        def on_next(s: str, i: int):
+        def on_next(s: str, i: int, max_e: int):
             nonlocal on_next_values
 
             if (s not in on_next_values):
                 on_next_values[s] = []
 
             on_next_values[s].append(i)
+
+            # Make sure this value is set
+            assert max_emissions == max_e
 
         def on_error(e):
             nonlocal on_error_count
@@ -444,6 +466,9 @@ def test_sink_function_unpacking(single_segment_pipeline, node_type: str):
         def on_completed():
             nonlocal on_completed_count
             on_completed_count += 1
+
+        if (use_partial):
+            on_next = functools.partial(on_next, max_e=max_emissions)
 
         if (is_component):
             sink = seg.make_sink_component("sink", on_next, on_error, on_completed)


### PR DESCRIPTION
If you used `functools.partial` with any operator function, it would incorrectly thing you wanted to unpack tuples into arguments. This improves on the function signature handling to support using partial functions.

Also includes fixes to the conda build.