### PR TITLE
Add handling for empty downstream sources

### DIFF
--- a/cpp/mrc/include/mrc/node/sink_channel_owner.hpp
+++ b/cpp/mrc/include/mrc/node/sink_channel_owner.hpp
@@ -51,11 +51,14 @@ class SinkChannelOwner : public virtual SinkProperties<T>
         auto channel_reader = edge_channel.get_reader();
         auto channel_writer = edge_channel.get_writer();
 
-        SinkProperties<T>::init_owned_edge(channel_writer);
+        channel_writer->add_connector([this, channel_reader]() {
+            // Finally, set the other half as the connected edge to allow readers the ability to pull from the channel.
+            // Only do this after a full connection has been made to avoid reading from a channel that will never be
+            // written to
+            SinkProperties<T>::init_connected_edge(channel_reader);
+        });
 
-        // Finally, set the other half to m_set_edge to allow using the channel without it being deleted. If set_edge()
-        // is called, then this will be overwritten
-        SinkProperties<T>::init_connected_edge(channel_reader);
+        SinkProperties<T>::init_owned_edge(channel_writer);
     }
 };
 

--- a/cpp/mrc/include/mrc/node/sink_properties.hpp
+++ b/cpp/mrc/include/mrc/node/sink_properties.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "mrc/channel/status.hpp"  // IWYU pragma: export
 #include "mrc/edge/edge_builder.hpp"
 #include "mrc/edge/edge_readable.hpp"
 #include "mrc/node/forward.hpp"

--- a/cpp/mrc/include/mrc/node/source_channel_owner.hpp
+++ b/cpp/mrc/include/mrc/node/source_channel_owner.hpp
@@ -53,11 +53,14 @@ class SourceChannelOwner : public virtual SourceProperties<T>
         auto channel_reader = edge_channel.get_reader();
         auto channel_writer = edge_channel.get_writer();
 
-        SourceProperties<T>::init_owned_edge(channel_reader);
+        channel_reader->add_connector([this, channel_writer]() {
+            // Finally, set the other half as the connected edge to allow writers the ability to push to the channel.
+            // Only do this after a full connection has been made to avoid writing to a channel that will never be
+            // read from.
+            SourceProperties<T>::init_connected_edge(channel_writer);
+        });
 
-        // Finally, set the other half to the connected edge to allow using the channel without it being deleted. If
-        // make_edge_connection() is called, then this will be overwritten
-        SourceProperties<T>::init_connected_edge(channel_writer);
+        SourceProperties<T>::init_owned_edge(channel_reader);
     }
 };
 

--- a/cpp/mrc/include/mrc/node/source_properties.hpp
+++ b/cpp/mrc/include/mrc/node/source_properties.hpp
@@ -18,8 +18,9 @@
 #pragma once
 
 #include "mrc/channel/ingress.hpp"
-#include "mrc/channel/status.hpp"
+#include "mrc/channel/status.hpp"  // IWYU pragma: export
 #include "mrc/edge/edge_builder.hpp"
+#include "mrc/edge/edge_writable.hpp"
 #include "mrc/node/forward.hpp"
 #include "mrc/type_traits.hpp"
 #include "mrc/utils/type_utils.hpp"

--- a/cpp/mrc/src/tests/segments/common_segments.cpp
+++ b/cpp/mrc/src/tests/segments/common_segments.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/src/tests/segments/common_segments.cpp
+++ b/cpp/mrc/src/tests/segments/common_segments.cpp
@@ -17,7 +17,6 @@
 
 #include "../nodes/common_nodes.hpp"
 
-#include "mrc/channel/status.hpp"
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/node/rx_source.hpp"
 #include "mrc/segment/builder.hpp"

--- a/cpp/mrc/src/tests/test_pipeline.cpp
+++ b/cpp/mrc/src/tests/test_pipeline.cpp
@@ -28,7 +28,6 @@
 #include "internal/utils/collision_detector.hpp"
 
 #include "mrc/channel/channel.hpp"
-#include "mrc/channel/status.hpp"
 #include "mrc/core/addresses.hpp"
 #include "mrc/core/executor.hpp"
 #include "mrc/data/reusable_pool.hpp"

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -786,6 +786,24 @@ TEST_F(TestEdges, CombineLatest)
     sink->run();
 }
 
+TEST_F(TestEdges, SourceToNull)
+{
+    auto source = std::make_shared<node::TestSource<int>>();
+
+    source->run();
+}
+
+TEST_F(TestEdges, SourceToNodeToNull)
+{
+    auto source = std::make_shared<node::TestSource<int>>();
+    auto node   = std::make_shared<node::TestNode<int>>();
+
+    mrc::make_edge(*source, *node);
+
+    source->run();
+    node->run();
+}
+
 TEST_F(TestEdges, CreateAndDestroy)
 {
     {

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -19,7 +19,6 @@
 
 #include "mrc/channel/buffered_channel.hpp"  // IWYU pragma: keep
 #include "mrc/channel/forward.hpp"
-#include "mrc/channel/status.hpp"
 #include "mrc/edge/edge_builder.hpp"
 #include "mrc/edge/edge_channel.hpp"
 #include "mrc/edge/edge_readable.hpp"

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -337,22 +337,6 @@ class PythonNode : public node::RxNode<InputT, OutputT, ContextT>,
             });
         };
     }
-
-  private:
-    channel::Status no_channel(OutputT&& data)
-    {
-        if constexpr (pybind11::detail::is_pyobject<OutputT>::value)
-        {
-            pybind11::gil_scoped_acquire gil;
-            OutputT tmp = std::move(data);
-        }
-        else
-        {
-            OutputT tmp = std::move(data);
-        }
-
-        return channel::Status::success;
-    }
 };
 
 template <typename InputT, typename OutputT>

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -25,7 +25,6 @@
 #include "pymrc/utilities/function_wrappers.hpp"
 #include "pymrc/utils.hpp"
 
-#include "mrc/channel/status.hpp"
 #include "mrc/edge/edge_builder.hpp"
 #include "mrc/node/port_registry.hpp"
 #include "mrc/node/rx_sink_base.hpp"

--- a/python/mrc/tests/test_edges.cpp
+++ b/python/mrc/tests/test_edges.cpp
@@ -22,7 +22,6 @@
 #include "pymrc/utilities/acquire_gil.hpp"
 #include "pymrc/utils.hpp"
 
-#include "mrc/channel/status.hpp"
 #include "mrc/edge/edge_connector.hpp"
 #include "mrc/node/rx_sink_base.hpp"
 #include "mrc/node/rx_source_base.hpp"

--- a/python/mrc/tests/test_edges.cpp
+++ b/python/mrc/tests/test_edges.cpp
@@ -122,7 +122,9 @@ class TestSourceImpl : public PythonTestNodeMixin
   public:
     using source_t = std::shared_ptr<T>;
 
-    TestSourceImpl(std::string name, pymrc::PyHolder counter) : PythonTestNodeMixin(std::move(name), std::move(counter))
+    TestSourceImpl(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
+      PythonTestNodeMixin(std::move(name), std::move(counter)),
+      m_msg_count(msg_count)
     {
         this->init_counter("on_next");
         this->init_counter("on_error");
@@ -133,7 +135,7 @@ class TestSourceImpl : public PythonTestNodeMixin
     auto build()
     {
         return rxcpp::observable<>::create<source_t>([this](rxcpp::subscriber<source_t>& output) {
-            for (size_t i = 0; i < 5; ++i)
+            for (size_t i = 0; i < m_msg_count; ++i)
             {
                 output.on_next(std::make_shared<T>());
                 this->increment_counter("on_next");
@@ -143,6 +145,8 @@ class TestSourceImpl : public PythonTestNodeMixin
             output.on_completed();
         });
     }
+
+    size_t m_msg_count{5};
 };
 
 template <typename T>
@@ -151,9 +155,9 @@ class TestSource : public pymrc::PythonSource<std::shared_ptr<T>>, public TestSo
   public:
     using base_t = pymrc::PythonSource<std::shared_ptr<T>>;
 
-    TestSource(std::string name, pymrc::PyHolder counter) :
+    TestSource(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
       base_t(),
-      TestSourceImpl<T>(std::move(name), std::move(counter))
+      TestSourceImpl<T>(std::move(name), std::move(counter), msg_count)
     {
         this->set_observable(this->build());
     }
@@ -165,9 +169,9 @@ class TestSourceComponent : public pymrc::PythonSourceComponent<std::shared_ptr<
   public:
     using base_t = pymrc::PythonSourceComponent<std::shared_ptr<T>>;
 
-    TestSourceComponent(std::string name, pymrc::PyHolder counter) :
+    TestSourceComponent(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
       base_t(build()),
-      TestSourceImpl<T>(std::move(name), std::move(counter))
+      TestSourceImpl<T>(std::move(name), std::move(counter), msg_count)
     {}
 
   private:
@@ -175,7 +179,7 @@ class TestSourceComponent : public pymrc::PythonSourceComponent<std::shared_ptr<
     typename base_t::get_data_fn_t build()
     {
         return [this](std::shared_ptr<T>& output) {
-            if (m_count++ < 5)
+            if (m_count++ < this->m_msg_count)
             {
                 output = std::make_shared<T>();
 
@@ -228,7 +232,8 @@ class TestNode : public pymrc::PythonNode<std::shared_ptr<T>, std::shared_ptr<T>
     using base_t = pymrc::PythonNode<std::shared_ptr<T>, std::shared_ptr<T>>;
 
   public:
-    TestNode(std::string name, pymrc::PyHolder counter) : TestNodeImpl<T>(std::move(name), std::move(counter))
+    TestNode(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
+      TestNodeImpl<T>(std::move(name), std::move(counter))
     {
         this->make_stream(this->build_operator());
     }
@@ -241,7 +246,8 @@ class TestNodeComponent : public pymrc::PythonNodeComponent<std::shared_ptr<T>, 
     using base_t = pymrc::PythonNodeComponent<std::shared_ptr<T>, std::shared_ptr<T>>;
 
   public:
-    TestNodeComponent(std::string name, pymrc::PyHolder counter) : TestNodeImpl<T>(std::move(name), std::move(counter))
+    TestNodeComponent(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
+      TestNodeImpl<T>(std::move(name), std::move(counter))
     {
         this->make_stream(this->build_operator());
     }
@@ -279,7 +285,8 @@ template <typename T>
 class TestSink : public pymrc::PythonSink<std::shared_ptr<T>>, public TestSinkImpl<T>
 {
   public:
-    TestSink(std::string name, pymrc::PyHolder counter) : TestSinkImpl<T>(std::move(name), std::move(counter))
+    TestSink(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
+      TestSinkImpl<T>(std::move(name), std::move(counter))
     {
         this->set_observer(this->build());
     }
@@ -289,7 +296,8 @@ template <typename T>
 class TestSinkComponent : public pymrc::PythonSinkComponent<std::shared_ptr<T>>, public TestSinkImpl<T>
 {
   public:
-    TestSinkComponent(std::string name, pymrc::PyHolder counter) : TestSinkImpl<T>(std::move(name), std::move(counter))
+    TestSinkComponent(std::string name, pymrc::PyHolder counter, size_t msg_count = 5) :
+      TestSinkImpl<T>(std::move(name), std::move(counter))
     {
         this->set_observer(this->build());
     }
@@ -302,17 +310,19 @@ GENERATE_NODE_TYPES(TestNodeComponent, NodeComponent);
 GENERATE_NODE_TYPES(TestSink, Sink);
 GENERATE_NODE_TYPES(TestSinkComponent, SinkComponent);
 
-#define CREATE_TEST_NODE_CLASS(class_name)                                                             \
-    py::class_<segment::Object<class_name>,                                                            \
-               mrc::segment::ObjectProperties,                                                         \
-               std::shared_ptr<segment::Object<class_name>>>(module, #class_name)                      \
-        .def(py::init<>([](mrc::segment::Builder& parent, const std::string& name, py::dict counter) { \
-                 auto stage = parent.construct_object<class_name>(name, name, std::move(counter));     \
-                 return stage;                                                                         \
-             }),                                                                                       \
-             py::arg("parent"),                                                                        \
-             py::arg("name"),                                                                          \
-             py::arg("counter"));
+#define CREATE_TEST_NODE_CLASS(class_name)                                                                        \
+    py::class_<segment::Object<class_name>,                                                                       \
+               mrc::segment::ObjectProperties,                                                                    \
+               std::shared_ptr<segment::Object<class_name>>>(module, #class_name)                                 \
+        .def(py::init<>(                                                                                          \
+                 [](mrc::segment::Builder& parent, const std::string& name, py::dict counter, size_t msg_count) { \
+                     auto stage = parent.construct_object<class_name>(name, name, std::move(counter), msg_count); \
+                     return stage;                                                                                \
+                 }),                                                                                              \
+             py::arg("parent"),                                                                                   \
+             py::arg("name"),                                                                                     \
+             py::arg("counter"),                                                                                  \
+             py::arg("msg_count") = 5);
 
 PYBIND11_MODULE(test_edges_cpp, module)
 {


### PR DESCRIPTION
Previously, we supported `source->node->[nothing]` where a source object didnt have any downstream sinks to write to. In that situation, the object was just discarded on writing. This fixes the edge functionality to replicate the previous system.