### PR TITLE
Update CMake to only add fcoroutines flag if clang version is less than 16 + bump to latest utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,8 +105,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       OUTPUT_VARIABLE clang_version_info
       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  string(REGEX MATCH "version [0-9]+" clang_version_line ${clang_version_info})
-  string(REGEX REPLACE "version ([0-9]+)" "\\1" clang_version ${clang_version_line})
+  string(REGEX MATCH "version [0-9]+" clang_version_value ${clang_version_info})
+  string(REGEX REPLACE "version ([0-9]+)" "\\1" clang_version ${clang_version_value})
 
   if(${clang_version} VERSION_LESS_EQUAL "15")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,18 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # Our version of NVCC officially only supports clang versions 3.2 - 13, we are now using 14
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler")
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts")
+  # Check if the major version of Clang is greater than 15
+  execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "--version"
+      OUTPUT_VARIABLE clang_version_info
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  string(REGEX MATCH "version [0-9]+" clang_version_line ${clang_version_info})
+  string(REGEX REPLACE "version ([0-9]+)" "\\1" clang_version ${clang_version_line})
+
+  if(${clang_version} VERSION_LESS_EQUAL "15")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts")
+  endif()
+
 endif()
 
 # Now enable CUDA


### PR DESCRIPTION
Clang will complain about deprecated flags if you pass fcoroutines to 16 or higher; this handles both cases and avoids warning spam.