### PR TITLE
Update `sccache` bucket

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -19,9 +19,6 @@ run-name: CI Pipeline
 on:
   workflow_call:
     inputs:
-      aws_region:
-        default: 'us-west-2'
-        type: string
       run_check:
         required: true
         type: boolean
@@ -47,7 +44,6 @@ on:
         required: true
 
 env:
-  AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
   AWS_ACCESS_KEY_ID: "${{ secrets.GHA_AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY: "${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}"
   CHANGE_TARGET: "${{ github.base_ref }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,8 +33,8 @@ jobs:
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230131
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230131
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230213
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230213
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/ci/scripts/github/build.sh
+++ b/ci/scripts/github/build.sh
@@ -26,6 +26,7 @@ rapids-logger "Check versions"
 python3 --version
 cmake --version
 ninja --version
+sccache --version
 
 if [[ "${BUILD_CC}" == "gcc" ]]; then
     rapids-logger "Building with GCC"

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -59,8 +59,8 @@ export DISPLAY_ARTIFACT_URL="${DISPLAY_URL}${ARTIFACT_ENDPOINT}"
 
 # Set sccache env vars
 export SCCACHE_S3_KEY_PREFIX=mrc-${NVARCH}-${BUILD_CC}
-export SCCACHE_BUCKET=rapids-sccache
-export SCCACHE_REGION="${AWS_DEFAULT_REGION}"
+export SCCACHE_BUCKET=rapids-sccache-east
+export SCCACHE_REGION="us-east-2"
 export SCCACHE_IDLE_TIMEOUT=32768
 #export SCCACHE_LOG=debug
 


### PR DESCRIPTION
This PR updates the `sccache` configuration settings to use a new bucket, `rapids-sccache-east`.

Unlike the previous `rapids-sccache` bucket, `rapids-sccache-east` resides in the same AWS region as the rest of our CI infrastructure (`us-east-2`).

This should result in faster, more reliable `sccache` connections and will also help keep our data transfer costs down.

**Important Note**: The changes from [this `sccache` PR](https://github.com/mozilla/sccache/pull/1403) are required to use a bucket in `us-east-2`. These changes were incorporated in `sccache` `v0.3.2`, so you'll need that version or later (preferably the latest, `v0.3.3`). Please ensure that your CI images satisfy this constraint before merging this PR.

Additionally, this PR updates the `SCCACHE_REGION` to the region of the bucket. This value is not meant to be a variable.