### PR TITLE
Cleanup top-level forward.hpp and types.hpp

### DIFF
--- a/cpp/mrc/include/mrc/forward.hpp
+++ b/cpp/mrc/include/mrc/forward.hpp
@@ -20,36 +20,15 @@
 namespace mrc {
 
 class Executor;
-class ExecutorBase;
 
-template <typename T>
-class NetworkDeserializer;
-
-class Options;
-
-class Runtime;
-
-class Placement;
-class PlacementGroup;
+struct PlacementGroup;
 
 namespace pipeline {
 class Pipeline;
 }  // namespace pipeline
 
-class PipelineConfiguration;
-
-class SegmentResources;
-
-class PipelineInstanceResources;
-
-class PipelineConfiguration;
-class SegmentConfiguration;
-
-class PipelineAssignment;
-class SegmentAssignment;
-
-class Cpuset;
-class NumaSet;
+struct CpuSet;
+struct NumaSet;
 
 class Options;
 class FiberPoolOptions;

--- a/cpp/mrc/include/mrc/types.hpp
+++ b/cpp/mrc/include/mrc/types.hpp
@@ -24,9 +24,6 @@
 
 namespace mrc {
 
-// template<class T>
-// using blocking_queue = boost::fibers::buffered_channel<T>;
-
 // Typedefs
 template <typename T>
 using Promise = userspace_threads::promise<T>;  // NOLINT(readability-identifier-naming)
@@ -45,27 +42,15 @@ using MachineID  = std::uint64_t;  // NOLINT(readability-identifier-naming)
 using InstanceID = std::uint64_t;  // NOLINT(readability-identifier-naming)
 using TagID      = std::uint64_t;  // NOLINT(readability-identifier-naming)
 
-using NodeID   = std::uint32_t;  // NOLINT(readability-identifier-naming)
-using ObjectID = std::uint32_t;  // NOLINT(readability-identifier-naming)
-
 template <typename T>
 using Handle = std::shared_ptr<T>;  // NOLINT(readability-identifier-naming)
 
-using SegmentName    = std::string;    // NOLINT(readability-identifier-naming)
 using SegmentID      = std::uint16_t;  // NOLINT(readability-identifier-naming)
 using SegmentRank    = std::uint16_t;  // NOLINT(readability-identifier-naming)
 using SegmentAddress = std::uint32_t;  // NOLINT(readability-identifier-naming) // id + rank
 
 using PortName    = std::string;    // NOLINT(readability-identifier-naming)
 using PortID      = std::uint16_t;  // NOLINT(readability-identifier-naming)
-using PortGroup   = std::uint32_t;  // NOLINT(readability-identifier-naming)  // port + group_id
 using PortAddress = std::uint64_t;  // NOLINT(readability-identifier-naming)  // id + rank + port
-
-using CpuID = std::uint32_t;  // NOLINT(readability-identifier-naming)
-using GpuID = std::uint32_t;  // NOLINT(readability-identifier-naming)
-
-using ResourceGroupID = std::size_t;  // NOLINT(readability-identifier-naming)
-
-using Tags = std::vector<SegmentAddress>;  // NOLINT
 
 }  // namespace mrc


### PR DESCRIPTION
* Remove forward declares for classes that no longer exist, or no longer exist in the top-level `mrc` namespace.
* Remove duplicate entries.
* Forward-declare structs as structs.
* Fix casing of `CpuSet` & `NumaSet` structs.
* Remove unused type-aliases from `types.hpp`, this could be a potentially breaking change if any users were using these types.

fixes #291