### PR TITLE
Pointer cast macro

### DIFF
--- a/cpp/mrc/include/mrc/utils/macros.hpp
+++ b/cpp/mrc/include/mrc/utils/macros.hpp
@@ -29,7 +29,7 @@
     #define MRC_PTR_CAST(PTR_T, ptr) DCHECK_NOTNULL(std::dynamic_pointer_cast<PTR_T>(ptr))
 #endif
 
-#ifndef DELETE_COPYABILITYp
+#ifndef DELETE_COPYABILITY
     #define DELETE_COPYABILITY(foo)                \
         foo(const foo&)                  = delete; \
         foo& operator=(const foo& other) = delete;

--- a/cpp/mrc/include/mrc/utils/macros.hpp
+++ b/cpp/mrc/include/mrc/utils/macros.hpp
@@ -23,7 +23,13 @@
 // __COUNTER__ isnt standard but is supported by msvc, gcc and clang
 #define MRC_UNIQUE_VAR_NAME(prefix) MRC_CONCAT_EVAL(prefix, __COUNTER__)
 
-#ifndef DELETE_COPYABILITY
+#if defined(NDEBUG)
+    #define MRC_PTR_CAST(PTR_T, ptr) std::static_pointer_cast<PTR_T>(ptr)
+#else
+    #define MRC_PTR_CAST(PTR_T, ptr) DCHECK_NOTNULL(std::dynamic_pointer_cast<PTR_T>(ptr))
+#endif
+
+#ifndef DELETE_COPYABILITYp
     #define DELETE_COPYABILITY(foo)                \
         foo(const foo&)                  = delete; \
         foo& operator=(const foo& other) = delete;

--- a/cpp/mrc/tests/CMakeLists.txt
+++ b/cpp/mrc/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(test_mrc
   test_channel.cpp
   test_edges.cpp
   test_executor.cpp
+  test_macros.cpp
   test_main.cpp
   test_metrics.cpp
   test_mrc.cpp

--- a/cpp/mrc/tests/test_macros.cpp
+++ b/cpp/mrc/tests/test_macros.cpp
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_mrc.hpp"  // IWYU pragma: associated
+
+#include "mrc/utils/macros.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <type_traits>
+
+namespace {
+class A
+{
+  public:
+    A(int val) : val(val) {}
+    int val;
+};
+
+class B : public A
+{};
+}  // namespace
+
+TEST_CLASS(Macros);
+
+TEST_F(TestMacros, MRC_PTR_CAST)
+{
+    // We can't test the fail case as that terminates,
+    // in addition to that we run tests in CI against release not debug builds
+    auto b_ptr = std::make_shared<B>(5);
+    auto a_ptr = MRC_PTR_CAST(A, b_ptr);
+
+    EXPECT_NE(a_ptr, nullptr);
+    EXPECT_EQ(a_ptr->val, 5);
+}

--- a/cpp/mrc/tests/test_macros.cpp
+++ b/cpp/mrc/tests/test_macros.cpp
@@ -19,7 +19,7 @@
 
 #include "mrc/utils/macros.hpp"
 
-#include <glog/logging.h>
+#include <glog/logging.h>  // IWYU pragma: keep
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/cpp/mrc/tests/test_macros.cpp
+++ b/cpp/mrc/tests/test_macros.cpp
@@ -23,7 +23,6 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <type_traits>
 
 namespace {
 class A
@@ -34,7 +33,10 @@ class A
 };
 
 class B : public A
-{};
+{
+  public:
+    B(int val) : A(val) {}
+};
 }  // namespace
 
 TEST_CLASS(Macros);


### PR DESCRIPTION
In debug it uses a dynamic cast and asserts not null, in release it uses a static cast.

In Morpheus I have a bunch of code that looks like:
```
    DCHECK(std::dynamic_pointer_cast<morpheus::InferenceMemory>(self.memory) != nullptr);
    return std::static_pointer_cast<morpheus::InferenceMemory>(self.memory);
```

This would allow for:
```
    return MRC_PTR_CAST(morpheus::InferenceMemory, self.memory);
```

Related to: https://github.com/nv-morpheus/Morpheus/issues/735