### PR TITLE
Use AWS OIDC to get AWS creds

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -36,16 +36,10 @@ on:
         required: true
       CONDA_TOKEN:
         required: true
-      GHA_AWS_ACCESS_KEY_ID:
-        required: true
-      GHA_AWS_SECRET_ACCESS_KEY:
-        required: true
       NGC_API_KEY:
         required: true
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.GHA_AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}"
   CHANGE_TARGET: "${{ github.base_ref }}"
   GH_TOKEN: "${{ github.token }}"
   GIT_COMMIT: "${{ github.sha }}"
@@ -67,6 +61,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -75,6 +71,12 @@ jobs:
           lfs: false
           path: 'mrc'
           fetch-depth: 0
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Check
         shell: bash
@@ -93,6 +95,8 @@ jobs:
       fail-fast: true
       matrix:
         build_cc: ["gcc", "clang"]
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -100,6 +104,12 @@ jobs:
         with:
           lfs: false
           path: 'mrc'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Build:linux:x86_64
         shell: bash
@@ -125,6 +135,8 @@ jobs:
       fail-fast: true
       matrix:
         build_cc: ["gcc", "clang"]
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -132,6 +144,12 @@ jobs:
         with:
           lfs: false
           path: 'mrc'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Test:linux:x86_64
         shell: bash
@@ -155,6 +173,8 @@ jobs:
       image: ${{ inputs.test_container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -162,6 +182,12 @@ jobs:
         with:
           lfs: false
           path: 'mrc'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Build
         shell: bash
@@ -185,6 +211,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -192,6 +220,12 @@ jobs:
         with:
           lfs: false
           path: 'mrc'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: build_docs
         shell: bash
@@ -210,6 +244,8 @@ jobs:
       options: --cap-add=sys_nice
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -217,6 +253,12 @@ jobs:
         with:
           lfs: false
           path: 'mrc'
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: pre_benchmark
         shell: bash
@@ -242,6 +284,8 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -250,6 +294,12 @@ jobs:
           lfs: false
           path: 'mrc'
           fetch-depth: 0
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: conda
         shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,6 +30,8 @@ concurrency:
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml
+    permissions:
+      id-token: write
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
@@ -38,6 +40,4 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}
-      GHA_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_ACCESS_KEY_ID }}
-      GHA_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_SECRET_ACCESS_KEY }}
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}


### PR DESCRIPTION
This PR is using the AWS OIDC to get AWS credentials ([doc](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)). Currently we are using permanent tokens that we need to manually rotate every 90 days. This PR is removing this requirement.

The `AWS_ROLE_ARN` and `AWS_REGION` are orgs variables defined here: https://github.com/organizations/nv-morpheus/settings/variables/actions.