### PR TITLE
Update workflow `permissions` block

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -47,6 +47,20 @@ env:
   WORKSPACE: "${{ github.workspace }}/mrc"
   WORKSPACE_TMP: "${{ github.workspace }}/tmp"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
   check:
@@ -61,8 +75,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -96,8 +108,6 @@ jobs:
       fail-fast: true
       matrix:
         build_cc: ["gcc", "clang"]
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -137,8 +147,6 @@ jobs:
       fail-fast: true
       matrix:
         build_cc: ["gcc", "clang"]
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -176,8 +184,6 @@ jobs:
       image: ${{ inputs.test_container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -215,8 +221,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -249,8 +253,6 @@ jobs:
       options: --cap-add=sys_nice
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout
@@ -290,8 +292,6 @@ jobs:
       image: ${{ inputs.container }}
     strategy:
       fail-fast: true
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,11 +27,24 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   ci_pipe:
     uses: ./.github/workflows/ci_pipe.yml
-    permissions:
-      id-token: write
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}


### PR DESCRIPTION
This PR is a continuation of #294.

Omitting the other keys in the `permissions` block sets them to `none` ([src](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview)).

This is probably not a concern for `nv-morpheus`, but it caused issues for some private RAPIDS repositories so I wanted to update the `nv-morpheus` repos for consistency.

To remedy this, this PR includes the following changes:

- Keeps the `id-token` permission as `write`, but sets the remaining permissions as described in the `restricted` column [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
  - Also sets `pull_request` to `read` so that `fetch_base_branch` in `common.sh` can use it
- Moves the `permissions` blocks to the top of the workflows to DRY them up