### PR TITLE
Improvements to the python module generation CMake code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "morpheus_utils"]
 	path = external/utilities
 	url = https://github.com/nv-morpheus/utilities.git
-	branch = branch-23.01
+	branch = branch-23.03

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ morpheus_utils_initialize_package_manager(
 morpheus_utils_initialize_cuda_arch(mrc)
 
 project(mrc
-  VERSION 23.01.00
+  VERSION 23.03.00
   LANGUAGES C CXX
 )
 

--- a/docs/quickstart/CMakeLists.txt
+++ b/docs/quickstart/CMakeLists.txt
@@ -24,7 +24,7 @@ list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
 morpheus_utils_python_modules_ensure_python3()
 
 project(mrc-quickstart
-  VERSION 23.01
+  VERSION 23.03
   LANGUAGES C CXX
 )
 

--- a/docs/quickstart/CMakeLists.txt
+++ b/docs/quickstart/CMakeLists.txt
@@ -17,23 +17,29 @@ list(APPEND CMAKE_MESSAGE_CONTEXT "quickstart")
 
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
+set(MRC_CACHE_DIR "${CMAKE_SOURCE_DIR}/.cache" CACHE PATH "Directory to contain all CPM and CCache data")
+mark_as_advanced(MRC_CACHE_DIR)
+
 # Add the Conda environment to the prefix path and add the CMake files
 list(PREPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../external/utilities/cmake")
 
-morpheus_utils_python_modules_ensure_python3()
+include(morpheus_utils/load)
 
 project(mrc-quickstart
   VERSION 23.03
   LANGUAGES C CXX
 )
 
+morpheus_utils_initialize_cpm(MRC_CACHE_DIR)
+
 # Ensure CPM is initialized
 rapids_cpm_init()
 
 # Set the option prefix to match the outer project before including. Must be before find_package(mrc)
 set(OPTION_PREFIX "MRC")
-include(morpheus_utils/python/register_api)
+morpheus_utils_python_ensure_loaded()
 
 rapids_find_package(mrc REQUIRED)
 rapids_find_package(CUDAToolkit REQUIRED)

--- a/docs/quickstart/compile.sh
+++ b/docs/quickstart/compile.sh
@@ -24,8 +24,8 @@ echo "Runing CMake configure..."
 cmake -B ${BUILD_DIR} -GNinja \
    -DCMAKE_MESSAGE_CONTEXT_SHOW=ON \
    -DMRC_PYTHON_INPLACE_BUILD:BOOL=ON \
-   -DMRC_PYTHON_PERFORM_INSTALL:BOOL=ON `# Ensure all of the libraries are installed` \
-   ${CMAKE_CONFIGURE_EXTRA_ARGS:-""} .
+   -DMRC_PYTHON_PERFORM_INSTALL:BOOL=ON # Ensure all of the libraries are installed` \
+   ${CMAKE_CONFIGURE_EXTRA_ARGS:+CMAKE_CONFIGURE_EXTRA_ARGS} .
 
 echo "Running CMake build..."
 cmake --build ${BUILD_DIR} -j "$@"

--- a/docs/quickstart/environment_cpp.yml
+++ b/docs/quickstart/environment_cpp.yml
@@ -31,7 +31,7 @@ dependencies:
   - python=3.8
   - scikit-build>=0.12
   - spdlog=1.8.5
-  - mrc=23.01
+  - mrc=23.03
   - sysroot_linux-64=2.17
   - pip:
     - cython

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/common/CMakeLists.txt
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/common/CMakeLists.txt
@@ -15,8 +15,6 @@
 
 morpheus_utils_add_pybind11_library(
   data
-  # MODULE_ROOT
-  # ${QUICKSTART_HYBRID_HOME}
   SOURCE_FILES
     data.cpp
   LINK_TARGETS
@@ -30,8 +28,6 @@ target_include_directories(${common_data_target}
     ./include
 )
 
-morpheus_utils_inplace_build_copy(${common_data_target} ${CMAKE_CURRENT_SOURCE_DIR})
-
 morpheus_utils_add_pybind11_library(
   nodes
   SOURCE_FILES
@@ -41,8 +37,6 @@ morpheus_utils_add_pybind11_library(
   OUTPUT_TARGET
     nodes_data_target
 )
-
-morpheus_utils_inplace_build_copy(${nodes_data_target} ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Set this variable in the parent scope so other examples can link to it
 set(common_data_target ${common_data_target} PARENT_SCOPE)

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/ex00_wrap_data_objects/CMakeLists.txt
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/ex00_wrap_data_objects/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-morpheus_utils_add_pybind11_module(
+mrc_quickstart_add_pybind11_module(
   data
   MODULE_ROOT
     ${QUICKSTART_HYBRID_HOME}
@@ -24,5 +24,3 @@ morpheus_utils_add_pybind11_module(
   OUTPUT_TARGET
     data_target
 )
-
-morpheus_utils_inplace_build_copy(${data_target} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/ex01_wrap_nodes/CMakeLists.txt
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/ex01_wrap_nodes/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-morpheus_utils_add_pybind11_module(
+mrc_quickstart_add_pybind11_module(
   nodes
   MODULE_ROOT
     ${QUICKSTART_HYBRID_HOME}
@@ -24,5 +24,3 @@ morpheus_utils_add_pybind11_module(
   OUTPUT_TARGET
     nodes_target
 )
-
-morpheus_utils_inplace_build_copy(${nodes_target} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,31 +17,15 @@ list(APPEND CMAKE_MESSAGE_CONTEXT "python")
 
 find_package(CUDAToolkit REQUIRED)
 
-# Load the pybind11 dependency
-morpheus_utils_configure_pybind11()
-
-# Get the project name in uppercase if OPTION_PREFIX is not defined
-if(NOT DEFINED OPTION_PREFIX)
-  string(TOUPPER "${PROJECT_NAME}" OPTION_PREFIX)
-endif()
-
-option(${OPTION_PREFIX}_PYTHON_BUILD_STUBS "Whether or not to generated .pyi stub files for C++ Python modules. Disable to avoid requiring loading the NVIDIA GPU Driver during build" ON)
-option(${OPTION_PREFIX}_PYTHON_BUILD_WHEEL "Whether or not to build the morpheus .whl file" OFF)
-option(${OPTION_PREFIX}_PYTHON_INPLACE_BUILD "Whether or not to copy built python modules back to the source tree for debug purposes." OFF)
-option(${OPTION_PREFIX}_PYTHON_PERFORM_INSTALL "Whether or not to automatically `pip install` any built python library. WARNING: This may overwrite any existing installation of the same name." OFF)
 
 # Ensure python is configured
-morpheus_utils_python_configure()
+morpheus_utils_python_ensure_loaded()
 
-# set(Python3_FIND_VIRTUALENV "FIRST")
-# set(Python3_FIND_STRATEGY "LOCATION")
 
-# morpheus_utils_print_python_info()
+morpheus_utils_print_python_info()
 
 # Create the mrc python package
 morpheus_utils_create_python_package(mrc)
-
-
 
 # Add a few additional files to be copied
 file(GLOB pymrc_test_files "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.py")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,22 +17,31 @@ list(APPEND CMAKE_MESSAGE_CONTEXT "python")
 
 find_package(CUDAToolkit REQUIRED)
 
+# Load the pybind11 dependency
+morpheus_utils_configure_pybind11()
+
 # Get the project name in uppercase if OPTION_PREFIX is not defined
 if(NOT DEFINED OPTION_PREFIX)
   string(TOUPPER "${PROJECT_NAME}" OPTION_PREFIX)
 endif()
 
+option(${OPTION_PREFIX}_PYTHON_BUILD_STUBS "Whether or not to generated .pyi stub files for C++ Python modules. Disable to avoid requiring loading the NVIDIA GPU Driver during build" ON)
+option(${OPTION_PREFIX}_PYTHON_BUILD_WHEEL "Whether or not to build the morpheus .whl file" OFF)
 option(${OPTION_PREFIX}_PYTHON_INPLACE_BUILD "Whether or not to copy built python modules back to the source tree for debug purposes." OFF)
 option(${OPTION_PREFIX}_PYTHON_PERFORM_INSTALL "Whether or not to automatically `pip install` any built python library. WARNING: This may overwrite any existing installation of the same name." OFF)
-option(${OPTION_PREFIX}_PYTHON_BUILD_STUBS "Whether or not to generated .pyi stub files for C++ Python modules. Disable to avoid requiring loading the NVIDIA GPU Driver during build" ON)
 
-set(Python3_FIND_VIRTUALENV "FIRST")
-set(Python3_FIND_STRATEGY "LOCATION")
+# Ensure python is configured
+morpheus_utils_python_configure()
 
-morpheus_utils_print_python_info()
+# set(Python3_FIND_VIRTUALENV "FIRST")
+# set(Python3_FIND_STRATEGY "LOCATION")
+
+# morpheus_utils_print_python_info()
 
 # Create the mrc python package
 morpheus_utils_create_python_package(mrc)
+
+
 
 # Add a few additional files to be copied
 file(GLOB pymrc_test_files "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.py")
@@ -42,29 +51,13 @@ morpheus_utils_add_python_sources(
     ${pymrc_test_files}
 )
 
-
-# Save the root of the python for relative paths
-set(MRC_PY_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
-
-# A common macro for adding some default arguments to add_pybind11_module
-macro(mrc_add_pybind11_module)
-  # Build up the common arguments for add_pybind11_module
-  set(_common_args)
-  list(APPEND _common_args "LINK_TARGETS" "pymrc")
-
-  if(MRC_PYTHON_INPLACE_BUILD)
-    list(APPEND _common_args "COPY_INPLACE")
-  endif()
-
-  if(MRC_PYTHON_BUILD_STUBS)
-    list(APPEND _common_args "BUILD_STUBS")
-  endif()
-
-  # Forward all common arguments plus any arguments passed in
-  morpheus_utils_add_pybind11_module(${ARGN} ${_common_args})
-endmacro()
-
+# Build the pymrc library
 add_subdirectory(mrc/_pymrc)
+
+# Set the default link targets to avoid repeating this
+morpheus_utils_python_package_set_default_link_targets(pymrc)
+
+# Now add the python bindings
 add_subdirectory(mrc/core)
 
 # ##################################################################################################
@@ -78,10 +71,12 @@ if(MRC_BUILD_TESTS)
 endif()
 
 # Complete the python package
-set(extra_args "")
-
 if(MRC_PYTHON_INPLACE_BUILD)
   list(APPEND extra_args "IS_INPLACE")
+endif()
+
+if(MRC_PYTHON_BUILD_WHEEL)
+  list(APPEND extra_args "BUILD_WHEEL")
 endif()
 
 if(MRC_PYTHON_PERFORM_INSTALL)

--- a/python/mrc/_pymrc/CMakeLists.txt
+++ b/python/mrc/_pymrc/CMakeLists.txt
@@ -12,9 +12,7 @@
 # the License.
 # =============================================================================
 
-find_package(Python 3.8 REQUIRED COMPONENTS Development Interpreter)
-find_package(pybind11 REQUIRED)
-find_package(prometheus-cpp REQUIRED)
+# find_package(prometheus-cpp REQUIRED)
 
 # Keep all source files sorted!!!
 add_library(pymrc

--- a/python/mrc/_pymrc/CMakeLists.txt
+++ b/python/mrc/_pymrc/CMakeLists.txt
@@ -12,7 +12,9 @@
 # the License.
 # =============================================================================
 
-# find_package(prometheus-cpp REQUIRED)
+find_package(Python 3.8 REQUIRED COMPONENTS Development Interpreter)
+find_package(pybind11 REQUIRED)
+find_package(prometheus-cpp REQUIRED)
 
 # Keep all source files sorted!!!
 add_library(pymrc

--- a/python/mrc/_pymrc/tests/CMakeLists.txt
+++ b/python/mrc/_pymrc/tests/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "tests")
 
-find_package(pybind11 REQUIRED)
+# find_package(pybind11 REQUIRED)
 
 # Keep all source files sorted!!!
 add_executable(test_pymrc

--- a/python/mrc/_pymrc/tests/CMakeLists.txt
+++ b/python/mrc/_pymrc/tests/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 list(APPEND CMAKE_MESSAGE_CONTEXT "tests")
 
-# find_package(pybind11 REQUIRED)
+find_package(pybind11 REQUIRED)
 
 # Keep all source files sorted!!!
 add_executable(test_pymrc


### PR DESCRIPTION
This is the corresponding update to incorporate changes from https://github.com/nv-morpheus/utilities/pull/17.

Mainly this reorganizes the python CMake checks so they only get executed once. Significantly speeding up the configure step.