### PR TITLE
Use gpu-latest for runner tags instead of specific driver version

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -132,7 +132,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    runs-on: [self-hosted, linux, amd64, gpu-v100-520-1]
+    runs-on: [self-hosted, linux, amd64, gpu-latest]
     timeout-minutes: 60
     container:
       credentials:
@@ -171,7 +171,7 @@ jobs:
 
   codecov:
     name: Code Coverage
-    runs-on: [self-hosted, linux, amd64, gpu-v100-520-1]
+    runs-on: [self-hosted, linux, amd64, gpu-latest]
     timeout-minutes: 60
     container:
       credentials:


### PR DESCRIPTION
Moving from using a specific driver version to the latest one. This will remove the need to always update the workflow every time a new driver is added to the CI runners