### PR TITLE
Fix license headers to only use a single /* comment to exclude it from doxygen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Thirdparty code included in the source tree (that is not pulled in as an externa
 
 Ex:
 ```c++
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Thirdparty code included in the source tree (that is not pulled in as an externa
 
 Ex:
 ```
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/benchmarks/bench_coroutines.cpp
+++ b/cpp/mrc/benchmarks/bench_coroutines.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/benchmarks/bench_fibers.cpp
+++ b/cpp/mrc/benchmarks/bench_fibers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/benchmarks/bench_mrc.cpp
+++ b/cpp/mrc/benchmarks/bench_mrc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/benchmarks/bench_segment.cpp
+++ b/cpp/mrc/benchmarks/bench_segment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/benchmarks/main.cpp
+++ b/cpp/mrc/benchmarks/main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/api.hpp
+++ b/cpp/mrc/include/mrc/api.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/benchmarking/segment_watcher.hpp
+++ b/cpp/mrc/include/mrc/benchmarking/segment_watcher.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/benchmarking/trace_statistics.hpp
+++ b/cpp/mrc/include/mrc/benchmarking/trace_statistics.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/benchmarking/tracer.hpp
+++ b/cpp/mrc/include/mrc/benchmarking/tracer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/benchmarking/util.hpp
+++ b/cpp/mrc/include/mrc/benchmarking/util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/buffered_channel.hpp
+++ b/cpp/mrc/include/mrc/channel/buffered_channel.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/channel.hpp
+++ b/cpp/mrc/include/mrc/channel/channel.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/egress.hpp
+++ b/cpp/mrc/include/mrc/channel/egress.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/forward.hpp
+++ b/cpp/mrc/include/mrc/channel/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/ingress.hpp
+++ b/cpp/mrc/include/mrc/channel/ingress.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/null_channel.hpp
+++ b/cpp/mrc/include/mrc/channel/null_channel.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/recent_channel.hpp
+++ b/cpp/mrc/include/mrc/channel/recent_channel.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/status.hpp
+++ b/cpp/mrc/include/mrc/channel/status.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/channel/types.hpp
+++ b/cpp/mrc/include/mrc/channel/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/api.hpp
+++ b/cpp/mrc/include/mrc/codable/api.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/codable_protocol.hpp
+++ b/cpp/mrc/include/mrc/codable/codable_protocol.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/decode.hpp
+++ b/cpp/mrc/include/mrc/codable/decode.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/encode.hpp
+++ b/cpp/mrc/include/mrc/codable/encode.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/encoded_object.hpp
+++ b/cpp/mrc/include/mrc/codable/encoded_object.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/encoding_options.hpp
+++ b/cpp/mrc/include/mrc/codable/encoding_options.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/forward.hpp
+++ b/cpp/mrc/include/mrc/codable/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/fundamental_types.hpp
+++ b/cpp/mrc/include/mrc/codable/fundamental_types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/memory.hpp
+++ b/cpp/mrc/include/mrc/codable/memory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/memory_resources.hpp
+++ b/cpp/mrc/include/mrc/codable/memory_resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/protobuf_message.hpp
+++ b/cpp/mrc/include/mrc/codable/protobuf_message.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/storage_forwarder.hpp
+++ b/cpp/mrc/include/mrc/codable/storage_forwarder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/type_traits.hpp
+++ b/cpp/mrc/include/mrc/codable/type_traits.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/codable/types.hpp
+++ b/cpp/mrc/include/mrc/codable/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/constants.hpp
+++ b/cpp/mrc/include/mrc/constants.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/control_plane/api.hpp
+++ b/cpp/mrc/include/mrc/control_plane/api.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/control_plane/subscription_service_forwarder.hpp
+++ b/cpp/mrc/include/mrc/control_plane/subscription_service_forwarder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/addresses.hpp
+++ b/cpp/mrc/include/mrc/core/addresses.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/bitmap.hpp
+++ b/cpp/mrc/include/mrc/core/bitmap.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/concepts/not_void.hpp
+++ b/cpp/mrc/include/mrc/core/concepts/not_void.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,6 +22,9 @@
 namespace mrc::core::concepts {
 
 template <typename T>
-concept not_void = requires { requires not std::same_as<T, void>; };
+concept not_void = requires
+{
+    requires not std::same_as<T, void>;
+};
 
 }  // namespace mrc::core::concepts

--- a/cpp/mrc/include/mrc/core/context.hpp
+++ b/cpp/mrc/include/mrc/core/context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/device_partition.hpp
+++ b/cpp/mrc/include/mrc/core/device_partition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/error.hpp
+++ b/cpp/mrc/include/mrc/core/error.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/executor.hpp
+++ b/cpp/mrc/include/mrc/core/executor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/expected.hpp
+++ b/cpp/mrc/include/mrc/core/expected.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/fiber_meta_data.hpp
+++ b/cpp/mrc/include/mrc/core/fiber_meta_data.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/fiber_pool.hpp
+++ b/cpp/mrc/include/mrc/core/fiber_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/host_partition.hpp
+++ b/cpp/mrc/include/mrc/core/host_partition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/logging.hpp
+++ b/cpp/mrc/include/mrc/core/logging.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/runtime.hpp
+++ b/cpp/mrc/include/mrc/core/runtime.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/spin_lock_mutex.hpp
+++ b/cpp/mrc/include/mrc/core/spin_lock_mutex.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/task_queue.hpp
+++ b/cpp/mrc/include/mrc/core/task_queue.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/thread.hpp
+++ b/cpp/mrc/include/mrc/core/thread.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/thread_barrier.hpp
+++ b/cpp/mrc/include/mrc/core/thread_barrier.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/userspace_threads.hpp
+++ b/cpp/mrc/include/mrc/core/userspace_threads.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/utils.hpp
+++ b/cpp/mrc/include/mrc/core/utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/core/watcher.hpp
+++ b/cpp/mrc/include/mrc/core/watcher.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/concepts/awaitable.hpp
+++ b/cpp/mrc/include/mrc/coroutines/concepts/awaitable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/concepts/buffer.hpp
+++ b/cpp/mrc/include/mrc/coroutines/concepts/buffer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/concepts/executor.hpp
+++ b/cpp/mrc/include/mrc/coroutines/concepts/executor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/concepts/promise.hpp
+++ b/cpp/mrc/include/mrc/coroutines/concepts/promise.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/concepts/range_of.hpp
+++ b/cpp/mrc/include/mrc/coroutines/concepts/range_of.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/detail/void_value.hpp
+++ b/cpp/mrc/include/mrc/coroutines/detail/void_value.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/event.hpp
+++ b/cpp/mrc/include/mrc/coroutines/event.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/generator.hpp
+++ b/cpp/mrc/include/mrc/coroutines/generator.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/latch.hpp
+++ b/cpp/mrc/include/mrc/coroutines/latch.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/ring_buffer.hpp
+++ b/cpp/mrc/include/mrc/coroutines/ring_buffer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/schedule_policy.hpp
+++ b/cpp/mrc/include/mrc/coroutines/schedule_policy.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/sync_wait.hpp
+++ b/cpp/mrc/include/mrc/coroutines/sync_wait.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/task.hpp
+++ b/cpp/mrc/include/mrc/coroutines/task.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/thread_local_context.hpp
+++ b/cpp/mrc/include/mrc/coroutines/thread_local_context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/thread_pool.hpp
+++ b/cpp/mrc/include/mrc/coroutines/thread_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/coroutines/when_all.hpp
+++ b/cpp/mrc/include/mrc/coroutines/when_all.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/cuda/common.hpp
+++ b/cpp/mrc/include/mrc/cuda/common.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/cuda/device_guard.hpp
+++ b/cpp/mrc/include/mrc/cuda/device_guard.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/cuda/sync.hpp
+++ b/cpp/mrc/include/mrc/cuda/sync.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/data/reusable_pool.hpp
+++ b/cpp/mrc/include/mrc/data/reusable_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/edge/deferred_edge.hpp
+++ b/cpp/mrc/include/mrc/edge/deferred_edge.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/edge/edge_adapter_registry.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_adapter_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/edge/edge_builder.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_builder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/edge/edge_connector.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_connector.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/edge/forward.hpp
+++ b/cpp/mrc/include/mrc/edge/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/executor/iexecutor.hpp
+++ b/cpp/mrc/include/mrc/engine/executor/iexecutor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/pipeline/ipipeline.hpp
+++ b/cpp/mrc/include/mrc/engine/pipeline/ipipeline.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/segment/forward.hpp
+++ b/cpp/mrc/include/mrc/engine/segment/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/segment/ibuilder.hpp
+++ b/cpp/mrc/include/mrc/engine/segment/ibuilder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/segment/idefinition.hpp
+++ b/cpp/mrc/include/mrc/engine/segment/idefinition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/system/iresources.hpp
+++ b/cpp/mrc/include/mrc/engine/system/iresources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/engine/system/isystem.hpp
+++ b/cpp/mrc/include/mrc/engine/system/isystem.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/exceptions/runtime_error.hpp
+++ b/cpp/mrc/include/mrc/exceptions/runtime_error.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/mirror_tap/mirror_tap.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/mirror_tap/mirror_tap.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/mirror_tap/mirror_tap_orchestrator.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/mirror_tap/mirror_tap_orchestrator.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/mirror_tap/mirror_tap_stream.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/mirror_tap/mirror_tap_stream.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_base.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_base.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_immediate.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_immediate.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_module.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_module.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_traits.hpp
+++ b/cpp/mrc/include/mrc/experimental/modules/stream_buffer/stream_buffer_traits.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,8 +25,9 @@
 namespace mrc::modules::stream_buffers {
 
 template <typename DataTypeT, template <typename> class StreamBufferTypeT>
-concept IsStreamBuffer = requires {
-                             typename StreamBufferTypeT<DataTypeT>;
-                             std::is_base_of_v<StreamBufferBase<DataTypeT>, StreamBufferTypeT<DataTypeT>>;
-                         };
+concept IsStreamBuffer = requires
+{
+    typename StreamBufferTypeT<DataTypeT>;
+    std::is_base_of_v<StreamBufferBase<DataTypeT>, StreamBufferTypeT<DataTypeT>>;
+};
 }  // namespace mrc::modules::stream_buffers

--- a/cpp/mrc/include/mrc/forward.hpp
+++ b/cpp/mrc/include/mrc/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/composite_manifold.hpp
+++ b/cpp/mrc/include/mrc/manifold/composite_manifold.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/connectable.hpp
+++ b/cpp/mrc/include/mrc/manifold/connectable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/egress.hpp
+++ b/cpp/mrc/include/mrc/manifold/egress.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/factory.hpp
+++ b/cpp/mrc/include/mrc/manifold/factory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/ingress.hpp
+++ b/cpp/mrc/include/mrc/manifold/ingress.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/interface.hpp
+++ b/cpp/mrc/include/mrc/manifold/interface.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/load_balancer.hpp
+++ b/cpp/mrc/include/mrc/manifold/load_balancer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/manifold/manifold.hpp
+++ b/cpp/mrc/include/mrc/manifold/manifold.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/adaptors.hpp
+++ b/cpp/mrc/include/mrc/memory/adaptors.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/buffer.hpp
+++ b/cpp/mrc/include/mrc/memory/buffer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/buffer_view.hpp
+++ b/cpp/mrc/include/mrc/memory/buffer_view.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/codable/buffer.hpp
+++ b/cpp/mrc/include/mrc/memory/codable/buffer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/literals.hpp
+++ b/cpp/mrc/include/mrc/memory/literals.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/memory_kind.hpp
+++ b/cpp/mrc/include/mrc/memory/memory_kind.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/resources/device/cuda_malloc_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/device/cuda_malloc_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/resources/host/malloc_memory_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/host/malloc_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/resources/host/pinned_memory_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/host/pinned_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/resources/logging_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/logging_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/memory/resources/memory_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/metrics/counter.hpp
+++ b/cpp/mrc/include/mrc/metrics/counter.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/metrics/registry.hpp
+++ b/cpp/mrc/include/mrc/metrics/registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/modules/module_registry.hpp
+++ b/cpp/mrc/include/mrc/modules/module_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/modules/module_registry_util.hpp
+++ b/cpp/mrc/include/mrc/modules/module_registry_util.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/modules/plugins.hpp
+++ b/cpp/mrc/include/mrc/modules/plugins.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/modules/properties/persistent.hpp
+++ b/cpp/mrc/include/mrc/modules/properties/persistent.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/modules/sample_modules.hpp
+++ b/cpp/mrc/include/mrc/modules/sample_modules.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/modules/segment_modules.hpp
+++ b/cpp/mrc/include/mrc/modules/segment_modules.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/mrc.hpp
+++ b/cpp/mrc/include/mrc/mrc.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/forward.hpp
+++ b/cpp/mrc/include/mrc/node/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/generic_node.hpp
+++ b/cpp/mrc/include/mrc/node/generic_node.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/generic_sink.hpp
+++ b/cpp/mrc/include/mrc/node/generic_sink.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/generic_source.hpp
+++ b/cpp/mrc/include/mrc/node/generic_source.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/operators/broadcast.hpp
+++ b/cpp/mrc/include/mrc/node/operators/broadcast.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/operators/conditional.hpp
+++ b/cpp/mrc/include/mrc/node/operators/conditional.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/operators/muxer.hpp
+++ b/cpp/mrc/include/mrc/node/operators/muxer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/operators/router.hpp
+++ b/cpp/mrc/include/mrc/node/operators/router.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/port_registry.hpp
+++ b/cpp/mrc/include/mrc/node/port_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/queue.hpp
+++ b/cpp/mrc/include/mrc/node/queue.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_epilogue_tap.hpp
+++ b/cpp/mrc/include/mrc/node/rx_epilogue_tap.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_execute.hpp
+++ b/cpp/mrc/include/mrc/node/rx_execute.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_node.hpp
+++ b/cpp/mrc/include/mrc/node/rx_node.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_prologue_tap.hpp
+++ b/cpp/mrc/include/mrc/node/rx_prologue_tap.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_runnable.hpp
+++ b/cpp/mrc/include/mrc/node/rx_runnable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_sink.hpp
+++ b/cpp/mrc/include/mrc/node/rx_sink.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_sink_base.hpp
+++ b/cpp/mrc/include/mrc/node/rx_sink_base.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_source.hpp
+++ b/cpp/mrc/include/mrc/node/rx_source.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_source_base.hpp
+++ b/cpp/mrc/include/mrc/node/rx_source_base.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/rx_subscribable.hpp
+++ b/cpp/mrc/include/mrc/node/rx_subscribable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/sink_channel_owner.hpp
+++ b/cpp/mrc/include/mrc/node/sink_channel_owner.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/sink_properties.hpp
+++ b/cpp/mrc/include/mrc/node/sink_properties.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/source_channel_owner.hpp
+++ b/cpp/mrc/include/mrc/node/source_channel_owner.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/source_properties.hpp
+++ b/cpp/mrc/include/mrc/node/source_properties.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/node/type_traits.hpp
+++ b/cpp/mrc/include/mrc/node/type_traits.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/engine_groups.hpp
+++ b/cpp/mrc/include/mrc/options/engine_groups.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/fiber_pool.hpp
+++ b/cpp/mrc/include/mrc/options/fiber_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/options.hpp
+++ b/cpp/mrc/include/mrc/options/options.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/placement.hpp
+++ b/cpp/mrc/include/mrc/options/placement.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/resources.hpp
+++ b/cpp/mrc/include/mrc/options/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/services.hpp
+++ b/cpp/mrc/include/mrc/options/services.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/options/topology.hpp
+++ b/cpp/mrc/include/mrc/options/topology.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pipeline/pipeline.hpp
+++ b/cpp/mrc/include/mrc/pipeline/pipeline.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pipeline/resources.hpp
+++ b/cpp/mrc/include/mrc/pipeline/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pubsub/api.hpp
+++ b/cpp/mrc/include/mrc/pubsub/api.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pubsub/forward.hpp
+++ b/cpp/mrc/include/mrc/pubsub/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pubsub/publisher.hpp
+++ b/cpp/mrc/include/mrc/pubsub/publisher.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pubsub/publisher_policy.hpp
+++ b/cpp/mrc/include/mrc/pubsub/publisher_policy.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/pubsub/subscriber.hpp
+++ b/cpp/mrc/include/mrc/pubsub/subscriber.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/context.hpp
+++ b/cpp/mrc/include/mrc/runnable/context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/detail/type_traits.hpp
+++ b/cpp/mrc/include/mrc/runnable/detail/type_traits.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/engine.hpp
+++ b/cpp/mrc/include/mrc/runnable/engine.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/engine_factory.hpp
+++ b/cpp/mrc/include/mrc/runnable/engine_factory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/fiber_context.hpp
+++ b/cpp/mrc/include/mrc/runnable/fiber_context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/forward.hpp
+++ b/cpp/mrc/include/mrc/runnable/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/internal_service.hpp
+++ b/cpp/mrc/include/mrc/runnable/internal_service.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/launch_control.hpp
+++ b/cpp/mrc/include/mrc/runnable/launch_control.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/launch_control_config.hpp
+++ b/cpp/mrc/include/mrc/runnable/launch_control_config.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/launch_options.hpp
+++ b/cpp/mrc/include/mrc/runnable/launch_options.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/launchable.hpp
+++ b/cpp/mrc/include/mrc/runnable/launchable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/launcher.hpp
+++ b/cpp/mrc/include/mrc/runnable/launcher.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/runnable.hpp
+++ b/cpp/mrc/include/mrc/runnable/runnable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/runner.hpp
+++ b/cpp/mrc/include/mrc/runnable/runner.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/runner_event.hpp
+++ b/cpp/mrc/include/mrc/runnable/runner_event.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/thread_context.hpp
+++ b/cpp/mrc/include/mrc/runnable/thread_context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/type_traits.hpp
+++ b/cpp/mrc/include/mrc/runnable/type_traits.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runnable/types.hpp
+++ b/cpp/mrc/include/mrc/runnable/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runtime/api.hpp
+++ b/cpp/mrc/include/mrc/runtime/api.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runtime/forward.hpp
+++ b/cpp/mrc/include/mrc/runtime/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runtime/remote_descriptor.hpp
+++ b/cpp/mrc/include/mrc/runtime/remote_descriptor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runtime/remote_descriptor_handle.hpp
+++ b/cpp/mrc/include/mrc/runtime/remote_descriptor_handle.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/runtime/remote_descriptor_manager.hpp
+++ b/cpp/mrc/include/mrc/runtime/remote_descriptor_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/builder.hpp
+++ b/cpp/mrc/include/mrc/segment/builder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -80,14 +80,14 @@ namespace {
 namespace hana = boost::hana;
 
 template <typename T>
-auto has_source_add_watcher = hana::is_valid(
-    [](auto&& thing) -> decltype(std::forward<decltype(thing)>(thing).source_add_watcher(
-                         std::declval<std::shared_ptr<mrc::WatcherInterface>>())) {});
+auto has_source_add_watcher =
+    hana::is_valid([](auto&& thing) -> decltype(std::forward<decltype(thing)>(thing).source_add_watcher(
+                                        std::declval<std::shared_ptr<mrc::WatcherInterface>>())) {});
 
 template <typename T>
-auto has_sink_add_watcher = hana::is_valid(
-    [](auto&& thing) -> decltype(std::forward<decltype(thing)>(thing).sink_add_watcher(
-                         std::declval<std::shared_ptr<mrc::WatcherInterface>>())) {});
+auto has_sink_add_watcher =
+    hana::is_valid([](auto&& thing) -> decltype(std::forward<decltype(thing)>(thing).sink_add_watcher(
+                                        std::declval<std::shared_ptr<mrc::WatcherInterface>>())) {});
 
 template <typename T>
 void add_stats_watcher_if_rx_source(T& thing, std::string name)

--- a/cpp/mrc/include/mrc/segment/component.hpp
+++ b/cpp/mrc/include/mrc/segment/component.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/context.hpp
+++ b/cpp/mrc/include/mrc/segment/context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/definition.hpp
+++ b/cpp/mrc/include/mrc/segment/definition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/egress_port.hpp
+++ b/cpp/mrc/include/mrc/segment/egress_port.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/egress_ports.hpp
+++ b/cpp/mrc/include/mrc/segment/egress_ports.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/forward.hpp
+++ b/cpp/mrc/include/mrc/segment/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/ingress_port.hpp
+++ b/cpp/mrc/include/mrc/segment/ingress_port.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/ingress_ports.hpp
+++ b/cpp/mrc/include/mrc/segment/ingress_ports.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/object.hpp
+++ b/cpp/mrc/include/mrc/segment/object.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/ports.hpp
+++ b/cpp/mrc/include/mrc/segment/ports.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/runnable.hpp
+++ b/cpp/mrc/include/mrc/segment/runnable.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/segment.hpp
+++ b/cpp/mrc/include/mrc/segment/segment.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/segment/utils.hpp
+++ b/cpp/mrc/include/mrc/segment/utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/type_traits.hpp
+++ b/cpp/mrc/include/mrc/type_traits.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/types.hpp
+++ b/cpp/mrc/include/mrc/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/bytes_to_string.hpp
+++ b/cpp/mrc/include/mrc/utils/bytes_to_string.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/logging.hpp
+++ b/cpp/mrc/include/mrc/utils/logging.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/macros.hpp
+++ b/cpp/mrc/include/mrc/utils/macros.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/runtime_validation_utils.hpp
+++ b/cpp/mrc/include/mrc/utils/runtime_validation_utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/sfinae_concept.hpp
+++ b/cpp/mrc/include/mrc/utils/sfinae_concept.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/sort_indexes.hpp
+++ b/cpp/mrc/include/mrc/utils/sort_indexes.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/string_utils.hpp
+++ b/cpp/mrc/include/mrc/utils/string_utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/thread_local_shared_pointer.hpp
+++ b/cpp/mrc/include/mrc/utils/thread_local_shared_pointer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/include/mrc/utils/type_utils.hpp
+++ b/cpp/mrc/include/mrc/utils/type_utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/codable_storage.cpp
+++ b/cpp/mrc/src/internal/codable/codable_storage.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/codable_storage.hpp
+++ b/cpp/mrc/src/internal/codable/codable_storage.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/decodable_storage_view.cpp
+++ b/cpp/mrc/src/internal/codable/decodable_storage_view.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/decodable_storage_view.hpp
+++ b/cpp/mrc/src/internal/codable/decodable_storage_view.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/storage_resources.hpp
+++ b/cpp/mrc/src/internal/codable/storage_resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/storage_view.cpp
+++ b/cpp/mrc/src/internal/codable/storage_view.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/codable/storage_view.hpp
+++ b/cpp/mrc/src/internal/codable/storage_view.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client.cpp
+++ b/cpp/mrc/src/internal/control_plane/client.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client.hpp
+++ b/cpp/mrc/src/internal/control_plane/client.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/connections_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/connections_manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/connections_manager.hpp
+++ b/cpp/mrc/src/internal/control_plane/client/connections_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/instance.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/instance.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/instance.hpp
+++ b/cpp/mrc/src/internal/control_plane/client/instance.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/state_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/state_manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/state_manager.hpp
+++ b/cpp/mrc/src/internal/control_plane/client/state_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/subscription_service.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/subscription_service.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/client/subscription_service.hpp
+++ b/cpp/mrc/src/internal/control_plane/client/subscription_service.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/proto_helpers.hpp
+++ b/cpp/mrc/src/internal/control_plane/proto_helpers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/resources.cpp
+++ b/cpp/mrc/src/internal/control_plane/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/resources.hpp
+++ b/cpp/mrc/src/internal/control_plane/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server.cpp
+++ b/cpp/mrc/src/internal/control_plane/server.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server.hpp
+++ b/cpp/mrc/src/internal/control_plane/server.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/client_instance.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/client_instance.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/connection_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/server/connection_manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/connection_manager.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/connection_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/subscription_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/server/subscription_manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/subscription_manager.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/subscription_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/tagged_issuer.cpp
+++ b/cpp/mrc/src/internal/control_plane/server/tagged_issuer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/tagged_issuer.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/tagged_issuer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/update_issuer.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/update_issuer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/control_plane/server/versioned_issuer.hpp
+++ b/cpp/mrc/src/internal/control_plane/server/versioned_issuer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/callbacks.cpp
+++ b/cpp/mrc/src/internal/data_plane/callbacks.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/callbacks.hpp
+++ b/cpp/mrc/src/internal/data_plane/callbacks.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/client.cpp
+++ b/cpp/mrc/src/internal/data_plane/client.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/client.hpp
+++ b/cpp/mrc/src/internal/data_plane/client.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/request.cpp
+++ b/cpp/mrc/src/internal/data_plane/request.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/request.hpp
+++ b/cpp/mrc/src/internal/data_plane/request.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/resources.cpp
+++ b/cpp/mrc/src/internal/data_plane/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/resources.hpp
+++ b/cpp/mrc/src/internal/data_plane/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/server.cpp
+++ b/cpp/mrc/src/internal/data_plane/server.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/server.hpp
+++ b/cpp/mrc/src/internal/data_plane/server.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/data_plane/tags.hpp
+++ b/cpp/mrc/src/internal/data_plane/tags.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/executor/executor.cpp
+++ b/cpp/mrc/src/internal/executor/executor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/executor/executor.hpp
+++ b/cpp/mrc/src/internal/executor/executor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/executor/iexecutor.cpp
+++ b/cpp/mrc/src/internal/executor/iexecutor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/forward.hpp
+++ b/cpp/mrc/src/internal/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/client_streaming.hpp
+++ b/cpp/mrc/src/internal/grpc/client_streaming.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/progress_engine.cpp
+++ b/cpp/mrc/src/internal/grpc/progress_engine.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/progress_engine.hpp
+++ b/cpp/mrc/src/internal/grpc/progress_engine.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/promise_handler.hpp
+++ b/cpp/mrc/src/internal/grpc/promise_handler.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/server.cpp
+++ b/cpp/mrc/src/internal/grpc/server.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/server.hpp
+++ b/cpp/mrc/src/internal/grpc/server.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/server_streaming.hpp
+++ b/cpp/mrc/src/internal/grpc/server_streaming.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/grpc/stream_writer.hpp
+++ b/cpp/mrc/src/internal/grpc/stream_writer.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/block_manager.hpp
+++ b/cpp/mrc/src/internal/memory/block_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/callback_adaptor.hpp
+++ b/cpp/mrc/src/internal/memory/callback_adaptor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/device_resources.cpp
+++ b/cpp/mrc/src/internal/memory/device_resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/device_resources.hpp
+++ b/cpp/mrc/src/internal/memory/device_resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/forward.hpp
+++ b/cpp/mrc/src/internal/memory/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/host_resources.cpp
+++ b/cpp/mrc/src/internal/memory/host_resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/host_resources.hpp
+++ b/cpp/mrc/src/internal/memory/host_resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/memory_block.hpp
+++ b/cpp/mrc/src/internal/memory/memory_block.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/transient_pool.cpp
+++ b/cpp/mrc/src/internal/memory/transient_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/memory/transient_pool.hpp
+++ b/cpp/mrc/src/internal/memory/transient_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/network/resources.cpp
+++ b/cpp/mrc/src/internal/network/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/network/resources.hpp
+++ b/cpp/mrc/src/internal/network/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/controller.cpp
+++ b/cpp/mrc/src/internal/pipeline/controller.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/controller.hpp
+++ b/cpp/mrc/src/internal/pipeline/controller.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/forward.hpp
+++ b/cpp/mrc/src/internal/pipeline/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/instance.cpp
+++ b/cpp/mrc/src/internal/pipeline/instance.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/instance.hpp
+++ b/cpp/mrc/src/internal/pipeline/instance.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/ipipeline.cpp
+++ b/cpp/mrc/src/internal/pipeline/ipipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/manager.cpp
+++ b/cpp/mrc/src/internal/pipeline/manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/manager.hpp
+++ b/cpp/mrc/src/internal/pipeline/manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/pipeline.cpp
+++ b/cpp/mrc/src/internal/pipeline/pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/pipeline.hpp
+++ b/cpp/mrc/src/internal/pipeline/pipeline.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/port_graph.cpp
+++ b/cpp/mrc/src/internal/pipeline/port_graph.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/port_graph.hpp
+++ b/cpp/mrc/src/internal/pipeline/port_graph.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/resources.cpp
+++ b/cpp/mrc/src/internal/pipeline/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/resources.hpp
+++ b/cpp/mrc/src/internal/pipeline/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pipeline/types.hpp
+++ b/cpp/mrc/src/internal/pipeline/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/placement_group.hpp
+++ b/cpp/mrc/src/internal/placement_group.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/base.hpp
+++ b/cpp/mrc/src/internal/pubsub/base.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/forward.hpp
+++ b/cpp/mrc/src/internal/pubsub/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/publisher_round_robin.cpp
+++ b/cpp/mrc/src/internal/pubsub/publisher_round_robin.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/publisher_round_robin.hpp
+++ b/cpp/mrc/src/internal/pubsub/publisher_round_robin.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/publisher_service.cpp
+++ b/cpp/mrc/src/internal/pubsub/publisher_service.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/publisher_service.hpp
+++ b/cpp/mrc/src/internal/pubsub/publisher_service.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/subscriber_service.cpp
+++ b/cpp/mrc/src/internal/pubsub/subscriber_service.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/pubsub/subscriber_service.hpp
+++ b/cpp/mrc/src/internal/pubsub/subscriber_service.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/decodable_storage.cpp
+++ b/cpp/mrc/src/internal/remote_descriptor/decodable_storage.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/decodable_storage.hpp
+++ b/cpp/mrc/src/internal/remote_descriptor/decodable_storage.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/forward.hpp
+++ b/cpp/mrc/src/internal/remote_descriptor/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/manager.cpp
+++ b/cpp/mrc/src/internal/remote_descriptor/manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/manager.hpp
+++ b/cpp/mrc/src/internal/remote_descriptor/manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/messages.hpp
+++ b/cpp/mrc/src/internal/remote_descriptor/messages.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/remote_descriptor.cpp
+++ b/cpp/mrc/src/internal/remote_descriptor/remote_descriptor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/remote_descriptor.hpp
+++ b/cpp/mrc/src/internal/remote_descriptor/remote_descriptor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/storage.cpp
+++ b/cpp/mrc/src/internal/remote_descriptor/storage.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/remote_descriptor/storage.hpp
+++ b/cpp/mrc/src/internal/remote_descriptor/storage.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/forward.hpp
+++ b/cpp/mrc/src/internal/resources/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/manager.cpp
+++ b/cpp/mrc/src/internal/resources/manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/manager.hpp
+++ b/cpp/mrc/src/internal/resources/manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/partition_resources.cpp
+++ b/cpp/mrc/src/internal/resources/partition_resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/partition_resources.hpp
+++ b/cpp/mrc/src/internal/resources/partition_resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/partition_resources_base.cpp
+++ b/cpp/mrc/src/internal/resources/partition_resources_base.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/resources/partition_resources_base.hpp
+++ b/cpp/mrc/src/internal/resources/partition_resources_base.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/engine.cpp
+++ b/cpp/mrc/src/internal/runnable/engine.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/engine.hpp
+++ b/cpp/mrc/src/internal/runnable/engine.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/engine_factory.cpp
+++ b/cpp/mrc/src/internal/runnable/engine_factory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/engine_factory.hpp
+++ b/cpp/mrc/src/internal/runnable/engine_factory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/engines.cpp
+++ b/cpp/mrc/src/internal/runnable/engines.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/engines.hpp
+++ b/cpp/mrc/src/internal/runnable/engines.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/fiber_engine.cpp
+++ b/cpp/mrc/src/internal/runnable/fiber_engine.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/fiber_engine.hpp
+++ b/cpp/mrc/src/internal/runnable/fiber_engine.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/fiber_engines.cpp
+++ b/cpp/mrc/src/internal/runnable/fiber_engines.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/fiber_engines.hpp
+++ b/cpp/mrc/src/internal/runnable/fiber_engines.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/resources.cpp
+++ b/cpp/mrc/src/internal/runnable/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/resources.hpp
+++ b/cpp/mrc/src/internal/runnable/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/thread_engine.cpp
+++ b/cpp/mrc/src/internal/runnable/thread_engine.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/thread_engine.hpp
+++ b/cpp/mrc/src/internal/runnable/thread_engine.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/thread_engines.cpp
+++ b/cpp/mrc/src/internal/runnable/thread_engines.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runnable/thread_engines.hpp
+++ b/cpp/mrc/src/internal/runnable/thread_engines.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runtime/partition.cpp
+++ b/cpp/mrc/src/internal/runtime/partition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runtime/partition.hpp
+++ b/cpp/mrc/src/internal/runtime/partition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runtime/runtime.cpp
+++ b/cpp/mrc/src/internal/runtime/runtime.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/runtime/runtime.hpp
+++ b/cpp/mrc/src/internal/runtime/runtime.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/builder.cpp
+++ b/cpp/mrc/src/internal/segment/builder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/builder.hpp
+++ b/cpp/mrc/src/internal/segment/builder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/definition.cpp
+++ b/cpp/mrc/src/internal/segment/definition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/definition.hpp
+++ b/cpp/mrc/src/internal/segment/definition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/ibuilder.cpp
+++ b/cpp/mrc/src/internal/segment/ibuilder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/idefinition.cpp
+++ b/cpp/mrc/src/internal/segment/idefinition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/instance.cpp
+++ b/cpp/mrc/src/internal/segment/instance.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/segment/instance.hpp
+++ b/cpp/mrc/src/internal/segment/instance.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/service.cpp
+++ b/cpp/mrc/src/internal/service.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/service.hpp
+++ b/cpp/mrc/src/internal/service.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/device_info.cpp
+++ b/cpp/mrc/src/internal/system/device_info.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/device_info.hpp
+++ b/cpp/mrc/src/internal/system/device_info.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/device_partition.cpp
+++ b/cpp/mrc/src/internal/system/device_partition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/device_partition.hpp
+++ b/cpp/mrc/src/internal/system/device_partition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/engine_factory_cpu_sets.cpp
+++ b/cpp/mrc/src/internal/system/engine_factory_cpu_sets.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/engine_factory_cpu_sets.hpp
+++ b/cpp/mrc/src/internal/system/engine_factory_cpu_sets.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_manager.cpp
+++ b/cpp/mrc/src/internal/system/fiber_manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_manager.hpp
+++ b/cpp/mrc/src/internal/system/fiber_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_pool.cpp
+++ b/cpp/mrc/src/internal/system/fiber_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_pool.hpp
+++ b/cpp/mrc/src/internal/system/fiber_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_priority_scheduler.hpp
+++ b/cpp/mrc/src/internal/system/fiber_priority_scheduler.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_task_queue.cpp
+++ b/cpp/mrc/src/internal/system/fiber_task_queue.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/fiber_task_queue.hpp
+++ b/cpp/mrc/src/internal/system/fiber_task_queue.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/forward.hpp
+++ b/cpp/mrc/src/internal/system/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/gpu_info.cpp
+++ b/cpp/mrc/src/internal/system/gpu_info.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/gpu_info.hpp
+++ b/cpp/mrc/src/internal/system/gpu_info.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/host_partition.cpp
+++ b/cpp/mrc/src/internal/system/host_partition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/host_partition.hpp
+++ b/cpp/mrc/src/internal/system/host_partition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/host_partition_provider.cpp
+++ b/cpp/mrc/src/internal/system/host_partition_provider.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/host_partition_provider.hpp
+++ b/cpp/mrc/src/internal/system/host_partition_provider.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/iresources.cpp
+++ b/cpp/mrc/src/internal/system/iresources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/isystem.cpp
+++ b/cpp/mrc/src/internal/system/isystem.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/partition.cpp
+++ b/cpp/mrc/src/internal/system/partition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/partition.hpp
+++ b/cpp/mrc/src/internal/system/partition.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/partition_provider.cpp
+++ b/cpp/mrc/src/internal/system/partition_provider.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/partition_provider.hpp
+++ b/cpp/mrc/src/internal/system/partition_provider.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/partitions.cpp
+++ b/cpp/mrc/src/internal/system/partitions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/partitions.hpp
+++ b/cpp/mrc/src/internal/system/partitions.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/resources.cpp
+++ b/cpp/mrc/src/internal/system/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/resources.hpp
+++ b/cpp/mrc/src/internal/system/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/system.cpp
+++ b/cpp/mrc/src/internal/system/system.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/system.hpp
+++ b/cpp/mrc/src/internal/system/system.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/system_provider.cpp
+++ b/cpp/mrc/src/internal/system/system_provider.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/system_provider.hpp
+++ b/cpp/mrc/src/internal/system/system_provider.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/thread.cpp
+++ b/cpp/mrc/src/internal/system/thread.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/thread.hpp
+++ b/cpp/mrc/src/internal/system/thread.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/thread_pool.cpp
+++ b/cpp/mrc/src/internal/system/thread_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/thread_pool.hpp
+++ b/cpp/mrc/src/internal/system/thread_pool.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/topology.cpp
+++ b/cpp/mrc/src/internal/system/topology.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/system/topology.hpp
+++ b/cpp/mrc/src/internal/system/topology.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/all.hpp
+++ b/cpp/mrc/src/internal/ucx/all.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/common.hpp
+++ b/cpp/mrc/src/internal/ucx/common.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/context.cpp
+++ b/cpp/mrc/src/internal/ucx/context.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/context.hpp
+++ b/cpp/mrc/src/internal/ucx/context.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/endpoint.cpp
+++ b/cpp/mrc/src/internal/ucx/endpoint.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/endpoint.hpp
+++ b/cpp/mrc/src/internal/ucx/endpoint.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/forward.hpp
+++ b/cpp/mrc/src/internal/ucx/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/memory_block.cpp
+++ b/cpp/mrc/src/internal/ucx/memory_block.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/memory_block.hpp
+++ b/cpp/mrc/src/internal/ucx/memory_block.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/primitive.hpp
+++ b/cpp/mrc/src/internal/ucx/primitive.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/receive_manager.cpp
+++ b/cpp/mrc/src/internal/ucx/receive_manager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/receive_manager.hpp
+++ b/cpp/mrc/src/internal/ucx/receive_manager.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/registation_callback_builder.hpp
+++ b/cpp/mrc/src/internal/ucx/registation_callback_builder.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/registration_cache.hpp
+++ b/cpp/mrc/src/internal/ucx/registration_cache.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/registration_resource.hpp
+++ b/cpp/mrc/src/internal/ucx/registration_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/remote_registration_cache.hpp
+++ b/cpp/mrc/src/internal/ucx/remote_registration_cache.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/resources.cpp
+++ b/cpp/mrc/src/internal/ucx/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/resources.hpp
+++ b/cpp/mrc/src/internal/ucx/resources.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/ucx.hpp
+++ b/cpp/mrc/src/internal/ucx/ucx.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/ucx_fwd.hpp
+++ b/cpp/mrc/src/internal/ucx/ucx_fwd.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/utils.hpp
+++ b/cpp/mrc/src/internal/ucx/utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/worker.cpp
+++ b/cpp/mrc/src/internal/ucx/worker.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/ucx/worker.hpp
+++ b/cpp/mrc/src/internal/ucx/worker.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/collision_detector.cpp
+++ b/cpp/mrc/src/internal/utils/collision_detector.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/collision_detector.hpp
+++ b/cpp/mrc/src/internal/utils/collision_detector.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/contains.hpp
+++ b/cpp/mrc/src/internal/utils/contains.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/exception_guard.cpp
+++ b/cpp/mrc/src/internal/utils/exception_guard.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/exception_guard.hpp
+++ b/cpp/mrc/src/internal/utils/exception_guard.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/parse_config.cpp
+++ b/cpp/mrc/src/internal/utils/parse_config.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/parse_config.hpp
+++ b/cpp/mrc/src/internal/utils/parse_config.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/parse_ints.cpp
+++ b/cpp/mrc/src/internal/utils/parse_ints.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/parse_ints.hpp
+++ b/cpp/mrc/src/internal/utils/parse_ints.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/ranges.hpp
+++ b/cpp/mrc/src/internal/utils/ranges.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/shared_resource_bit_map.cpp
+++ b/cpp/mrc/src/internal/utils/shared_resource_bit_map.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/internal/utils/shared_resource_bit_map.hpp
+++ b/cpp/mrc/src/internal/utils/shared_resource_bit_map.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/benchmarking/trace_statistics.cpp
+++ b/cpp/mrc/src/public/benchmarking/trace_statistics.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/benchmarking/tracer.cpp
+++ b/cpp/mrc/src/public/benchmarking/tracer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -232,11 +232,11 @@ void TraceAggregatorBase::process_tracer_data(const std::vector<std::shared_ptr<
     m_node_count      = segment_node_count;
     m_tracer_count    = tracers.size();
     m_json_data       = {
-        {
-            "metadata",
-            {{"elapsed_time", m_elapsed_seconds}, {"tracer_count", m_tracer_count}, {"node_count", m_node_count}},
+              {
+                  "metadata",
+                  {{"elapsed_time", m_elapsed_seconds}, {"tracer_count", m_tracer_count}, {"node_count", m_node_count}},
         },
-        {"aggregations", {}}};
+              {"aggregations", {}}};
 
     if (!cmpt_id_to_name.empty())
     {

--- a/cpp/mrc/src/public/benchmarking/util.cpp
+++ b/cpp/mrc/src/public/benchmarking/util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/channel/channel.cpp
+++ b/cpp/mrc/src/public/channel/channel.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/codable/encoded_object.cpp
+++ b/cpp/mrc/src/public/codable/encoded_object.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/codable/memory.cpp
+++ b/cpp/mrc/src/public/codable/memory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/core/addresses.cpp
+++ b/cpp/mrc/src/public/core/addresses.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/core/bitmap.cpp
+++ b/cpp/mrc/src/public/core/bitmap.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/core/executor.cpp
+++ b/cpp/mrc/src/public/core/executor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/core/fiber_pool.cpp
+++ b/cpp/mrc/src/public/core/fiber_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/core/logging.cpp
+++ b/cpp/mrc/src/public/core/logging.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/core/thread.cpp
+++ b/cpp/mrc/src/public/core/thread.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/coroutines/event.cpp
+++ b/cpp/mrc/src/public/coroutines/event.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/coroutines/sync_wait.cpp
+++ b/cpp/mrc/src/public/coroutines/sync_wait.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/coroutines/thread_local_context.cpp
+++ b/cpp/mrc/src/public/coroutines/thread_local_context.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/coroutines/thread_pool.cpp
+++ b/cpp/mrc/src/public/coroutines/thread_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/cuda/device_guard.cpp
+++ b/cpp/mrc/src/public/cuda/device_guard.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/cuda/sync.cpp
+++ b/cpp/mrc/src/public/cuda/sync.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/edge/edge_adapter_registry.cpp
+++ b/cpp/mrc/src/public/edge/edge_adapter_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/edge/edge_builder.cpp
+++ b/cpp/mrc/src/public/edge/edge_builder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/manifold/manifold.cpp
+++ b/cpp/mrc/src/public/manifold/manifold.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/memory/buffer_view.cpp
+++ b/cpp/mrc/src/public/memory/buffer_view.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/memory/codable/buffer.cpp
+++ b/cpp/mrc/src/public/memory/codable/buffer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/metrics/counter.cpp
+++ b/cpp/mrc/src/public/metrics/counter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/metrics/registry.cpp
+++ b/cpp/mrc/src/public/metrics/registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/modules/module_registry.cpp
+++ b/cpp/mrc/src/public/modules/module_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/modules/plugins.cpp
+++ b/cpp/mrc/src/public/modules/plugins.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/modules/sample_modules.cpp
+++ b/cpp/mrc/src/public/modules/sample_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/modules/segment_modules.cpp
+++ b/cpp/mrc/src/public/modules/segment_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/node/port_registry.cpp
+++ b/cpp/mrc/src/public/node/port_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/engine_groups.cpp
+++ b/cpp/mrc/src/public/options/engine_groups.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/fiber_pool.cpp
+++ b/cpp/mrc/src/public/options/fiber_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/options.cpp
+++ b/cpp/mrc/src/public/options/options.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/placement.cpp
+++ b/cpp/mrc/src/public/options/placement.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/resources.cpp
+++ b/cpp/mrc/src/public/options/resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/services.cpp
+++ b/cpp/mrc/src/public/options/services.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/options/topology.cpp
+++ b/cpp/mrc/src/public/options/topology.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/pipeline/pipeline.cpp
+++ b/cpp/mrc/src/public/pipeline/pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/runnable/context.cpp
+++ b/cpp/mrc/src/public/runnable/context.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/runnable/launcher.cpp
+++ b/cpp/mrc/src/public/runnable/launcher.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/runnable/runnable.cpp
+++ b/cpp/mrc/src/public/runnable/runnable.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/runnable/runner.cpp
+++ b/cpp/mrc/src/public/runnable/runner.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/runnable/types.cpp
+++ b/cpp/mrc/src/public/runnable/types.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/runtime/remote_descriptor.cpp
+++ b/cpp/mrc/src/public/runtime/remote_descriptor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/segment/builder.cpp
+++ b/cpp/mrc/src/public/segment/builder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/segment/definition.cpp
+++ b/cpp/mrc/src/public/segment/definition.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/utils/bytes_to_string.cpp
+++ b/cpp/mrc/src/public/utils/bytes_to_string.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/utils/thread_utils.cpp
+++ b/cpp/mrc/src/public/utils/thread_utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/utils/thread_utils.hpp
+++ b/cpp/mrc/src/public/utils/thread_utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/public/utils/type_utils.cpp
+++ b/cpp/mrc/src/public/utils/type_utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/common.cpp
+++ b/cpp/mrc/src/tests/common.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/common.hpp
+++ b/cpp/mrc/src/tests/common.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/nodes/common_nodes.cpp
+++ b/cpp/mrc/src/tests/nodes/common_nodes.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/nodes/common_nodes.hpp
+++ b/cpp/mrc/src/tests/nodes/common_nodes.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/pipelines/common_pipelines.hpp
+++ b/cpp/mrc/src/tests/pipelines/common_pipelines.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/pipelines/multi_segment.cpp
+++ b/cpp/mrc/src/tests/pipelines/multi_segment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/pipelines/single_segment.cpp
+++ b/cpp/mrc/src/tests/pipelines/single_segment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/segments/common_segments.cpp
+++ b/cpp/mrc/src/tests/segments/common_segments.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/segments/common_segments.hpp
+++ b/cpp/mrc/src/tests/segments/common_segments.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_codable.cpp
+++ b/cpp/mrc/src/tests/test_codable.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_control_plane.cpp
+++ b/cpp/mrc/src/tests/test_control_plane.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_control_plane_components.cpp
+++ b/cpp/mrc/src/tests/test_control_plane_components.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_expected.cpp
+++ b/cpp/mrc/src/tests/test_expected.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_grpc.cpp
+++ b/cpp/mrc/src/tests/test_grpc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_main.cpp
+++ b/cpp/mrc/src/tests/test_main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_memory.cpp
+++ b/cpp/mrc/src/tests/test_memory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_network.cpp
+++ b/cpp/mrc/src/tests/test_network.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_next.cpp
+++ b/cpp/mrc/src/tests/test_next.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_partitions.cpp
+++ b/cpp/mrc/src/tests/test_partitions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_pipeline.cpp
+++ b/cpp/mrc/src/tests/test_pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_ranges.cpp
+++ b/cpp/mrc/src/tests/test_ranges.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_remote_descriptor.cpp
+++ b/cpp/mrc/src/tests/test_remote_descriptor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_resources.cpp
+++ b/cpp/mrc/src/tests/test_resources.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_reusable_pool.cpp
+++ b/cpp/mrc/src/tests/test_reusable_pool.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_runnable.cpp
+++ b/cpp/mrc/src/tests/test_runnable.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_system.cpp
+++ b/cpp/mrc/src/tests/test_system.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_topology.cpp
+++ b/cpp/mrc/src/tests/test_topology.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tests/test_ucx.cpp
+++ b/cpp/mrc/src/tests/test_ucx.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/src/tools/topology_exporter.cpp
+++ b/cpp/mrc/src/tools/topology_exporter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/benchmarking/test_benchmarking.cpp
+++ b/cpp/mrc/tests/benchmarking/test_benchmarking.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/benchmarking/test_benchmarking.hpp
+++ b/cpp/mrc/tests/benchmarking/test_benchmarking.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/benchmarking/test_main.cpp
+++ b/cpp/mrc/tests/benchmarking/test_main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/benchmarking/test_stat_gather.cpp
+++ b/cpp/mrc/tests/benchmarking/test_stat_gather.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/benchmarking/test_stat_gather.hpp
+++ b/cpp/mrc/tests/benchmarking/test_stat_gather.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/benchmarking/test_utils.cpp
+++ b/cpp/mrc/tests/benchmarking/test_utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/coroutines/test_event.cpp
+++ b/cpp/mrc/tests/coroutines/test_event.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/coroutines/test_latch.cpp
+++ b/cpp/mrc/tests/coroutines/test_latch.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
+++ b/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/coroutines/test_task.cpp
+++ b/cpp/mrc/tests/coroutines/test_task.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/logging/test_logging.cpp
+++ b/cpp/mrc/tests/logging/test_logging.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/logging/test_main.cpp
+++ b/cpp/mrc/tests/logging/test_main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/dynamic_module.cpp
+++ b/cpp/mrc/tests/modules/dynamic_module.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_mirror_tap_module.cpp
+++ b/cpp/mrc/tests/modules/test_mirror_tap_module.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_mirror_tap_orchestrator.cpp
+++ b/cpp/mrc/tests/modules/test_mirror_tap_orchestrator.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_module_registry.cpp
+++ b/cpp/mrc/tests/modules/test_module_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_module_util.cpp
+++ b/cpp/mrc/tests/modules/test_module_util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_modules.hpp
+++ b/cpp/mrc/tests/modules/test_modules.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_segment_modules.cpp
+++ b/cpp/mrc/tests/modules/test_segment_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/modules/test_stream_buffer_modules.cpp
+++ b/cpp/mrc/tests/modules/test_stream_buffer_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_channel.cpp
+++ b/cpp/mrc/tests/test_channel.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_executor.cpp
+++ b/cpp/mrc/tests/test_executor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_macros.cpp
+++ b/cpp/mrc/tests/test_macros.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_main.cpp
+++ b/cpp/mrc/tests/test_main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_metrics.cpp
+++ b/cpp/mrc/tests/test_metrics.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_mrc.cpp
+++ b/cpp/mrc/tests/test_mrc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_mrc.hpp
+++ b/cpp/mrc/tests/test_mrc.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_node.cpp
+++ b/cpp/mrc/tests/test_node.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_pipeline.cpp
+++ b/cpp/mrc/tests/test_pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_segment.cpp
+++ b/cpp/mrc/tests/test_segment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_segment.hpp
+++ b/cpp/mrc/tests/test_segment.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/cpp/mrc/tests/test_thread.cpp
+++ b/cpp/mrc/tests/test_thread.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/cpp/common/include/nodes.hpp
+++ b/docs/quickstart/cpp/common/include/nodes.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/cpp/common/src/nodes.cpp
+++ b/docs/quickstart/cpp/common/src/nodes.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/cpp/ex00_simple_pipeline/simple_pipeline.cpp
+++ b/docs/quickstart/cpp/ex00_simple_pipeline/simple_pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/cpp/ex01_node_library/include/nodes.hpp
+++ b/docs/quickstart/cpp/ex01_node_library/include/nodes.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/cpp/ex01_node_library/src/nodes.cpp
+++ b/docs/quickstart/cpp/ex01_node_library/src/nodes.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/cpp/ex02_pipeline_with_library/pipeline_with_library.cpp
+++ b/docs/quickstart/cpp/ex02_pipeline_with_library/pipeline_with_library.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -50,8 +50,9 @@ int main(int argc, char* argv[])
         // A Node is both a Source and a Sink, it connects to an upstream provider/source and a downstream
         // subscriber/sink. This examples accects an upstream int and provides a downstream float which is the input
         // value scaled by 2.5.
-        auto node = s.make_node<int, float>("int_x2_to_float",
-                                            rxcpp::operators::map([](const int& data) { return float(2.5F * data); }));
+        auto node = s.make_node<int, float>("int_x2_to_float", rxcpp::operators::map([](const int& data) {
+                                                return float(2.5F * data);
+                                            }));
 
         // Sink
         // Sinks are terminators. They only accept upstream connections and do not provide the ability to pass data on.

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/common/data.cpp
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/common/data.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/common/nodes.cpp
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/common/nodes.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -78,8 +78,12 @@ class DataObjectNode
 
                     output.on_next(std::move(x));
                 },
-                [&](std::exception_ptr error_ptr) { output.on_error(error_ptr); },
-                [&]() { output.on_completed(); }));
+                [&](std::exception_ptr error_ptr) {
+                    output.on_error(error_ptr);
+                },
+                [&]() {
+                    output.on_completed();
+                }));
         };
     }
 
@@ -127,8 +131,9 @@ PYBIND11_MODULE(nodes, m)
 
     py::class_<mrc::segment::Object<DataObjectSource>,
                mrc::segment::ObjectProperties,
-               std::shared_ptr<mrc::segment::Object<DataObjectSource>>>(
-        m, "DataObjectSource", py::multiple_inheritance())
+               std::shared_ptr<mrc::segment::Object<DataObjectSource>>>(m,
+                                                                        "DataObjectSource",
+                                                                        py::multiple_inheritance())
         .def(py::init<>([](mrc::segment::Builder& parent, const std::string& name, size_t count) {
                  auto stage = parent.construct_object<DataObjectSource>(name, count);
 

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/ex00_wrap_data_objects/data.cpp
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/ex00_wrap_data_objects/data.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/ex01_wrap_nodes/nodes.cpp
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/ex01_wrap_nodes/nodes.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -74,8 +74,12 @@ class MyDataObjectNode
 
                     output.on_next(std::move(x));
                 },
-                [&](std::exception_ptr error_ptr) { output.on_error(error_ptr); },
-                [&]() { output.on_completed(); }));
+                [&](std::exception_ptr error_ptr) {
+                    output.on_error(error_ptr);
+                },
+                [&]() {
+                    output.on_completed();
+                }));
         };
     }
 
@@ -120,8 +124,9 @@ PYBIND11_MODULE(nodes, m)
 
     py::class_<mrc::segment::Object<MyDataObjectSource>,
                mrc::segment::ObjectProperties,
-               std::shared_ptr<mrc::segment::Object<MyDataObjectSource>>>(
-        m, "MyDataObjectSource", py::multiple_inheritance())
+               std::shared_ptr<mrc::segment::Object<MyDataObjectSource>>>(m,
+                                                                          "MyDataObjectSource",
+                                                                          py::multiple_inheritance())
         .def(py::init<>([](mrc::segment::Builder& parent, const std::string& name, size_t count) {
                  auto stage = parent.construct_object<MyDataObjectSource>(name, count);
 
@@ -133,8 +138,9 @@ PYBIND11_MODULE(nodes, m)
 
     py::class_<mrc::segment::Object<MyDataObjectNode>,
                mrc::segment::ObjectProperties,
-               std::shared_ptr<mrc::segment::Object<MyDataObjectNode>>>(
-        m, "MyDataObjectNode", py::multiple_inheritance())
+               std::shared_ptr<mrc::segment::Object<MyDataObjectNode>>>(m,
+                                                                        "MyDataObjectNode",
+                                                                        py::multiple_inheritance())
         .def(py::init<>([](mrc::segment::Builder& parent, const std::string& name) {
                  auto stage = parent.construct_object<MyDataObjectNode>(name);
 
@@ -145,8 +151,9 @@ PYBIND11_MODULE(nodes, m)
 
     py::class_<mrc::segment::Object<MyDataObjectSink>,
                mrc::segment::ObjectProperties,
-               std::shared_ptr<mrc::segment::Object<MyDataObjectSink>>>(
-        m, "MyDataObjectSink", py::multiple_inheritance())
+               std::shared_ptr<mrc::segment::Object<MyDataObjectSink>>>(m,
+                                                                        "MyDataObjectSink",
+                                                                        py::multiple_inheritance())
         .def(py::init<>([](mrc::segment::Builder& parent, const std::string& name) {
                  auto stage = parent.construct_object<MyDataObjectSink>(name);
 

--- a/protos/mrc/protos/architect.proto
+++ b/protos/mrc/protos/architect.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022,NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/protos/mrc/protos/codable.proto
+++ b/protos/mrc/protos/codable.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022,NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/protos/mrc/protos/remote_descriptor.proto
+++ b/protos/mrc/protos/remote_descriptor.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022,NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/protos/mrc/protos/tensor_meta_data.proto
+++ b/protos/mrc/protos/tensor_meta_data.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022,NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/protos/mrc/protos/test.proto
+++ b/protos/mrc/protos/test.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2018-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/codable_object.hpp
+++ b/python/mrc/_pymrc/include/pymrc/codable_object.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/edge_adapter.hpp
+++ b/python/mrc/_pymrc/include/pymrc/edge_adapter.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/executor.hpp
+++ b/python/mrc/_pymrc/include/pymrc/executor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/forward.hpp
+++ b/python/mrc/_pymrc/include/pymrc/forward.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/logging.hpp
+++ b/python/mrc/_pymrc/include/pymrc/logging.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/module_registry.hpp
+++ b/python/mrc/_pymrc/include/pymrc/module_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/module_wrappers/pickle.hpp
+++ b/python/mrc/_pymrc/include/pymrc/module_wrappers/pickle.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/module_wrappers/shared_memory.hpp
+++ b/python/mrc/_pymrc/include/pymrc/module_wrappers/shared_memory.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/options.hpp
+++ b/python/mrc/_pymrc/include/pymrc/options.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/pipeline.hpp
+++ b/python/mrc/_pymrc/include/pymrc/pipeline.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/plugins.hpp
+++ b/python/mrc/_pymrc/include/pymrc/plugins.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/port_builders.hpp
+++ b/python/mrc/_pymrc/include/pymrc/port_builders.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/py_segment_module.hpp
+++ b/python/mrc/_pymrc/include/pymrc/py_segment_module.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/segment.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/segment_modules.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment_modules.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/subscriber.hpp
+++ b/python/mrc/_pymrc/include/pymrc/subscriber.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/system.hpp
+++ b/python/mrc/_pymrc/include/pymrc/system.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utilities/acquire_gil.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/acquire_gil.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utilities/deserializers.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/deserializers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utilities/function_wrappers.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/function_wrappers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utilities/object_cache.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/object_cache.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utilities/object_wrappers.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/object_wrappers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utilities/serializers.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/serializers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/include/pymrc/watchers.hpp
+++ b/python/mrc/_pymrc/include/pymrc/watchers.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/executor.cpp
+++ b/python/mrc/_pymrc/src/executor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/logging.cpp
+++ b/python/mrc/_pymrc/src/logging.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/module_registry.cpp
+++ b/python/mrc/_pymrc/src/module_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/module_wrappers/pickle.cpp
+++ b/python/mrc/_pymrc/src/module_wrappers/pickle.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/module_wrappers/shared_memory.cpp
+++ b/python/mrc/_pymrc/src/module_wrappers/shared_memory.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/node.cpp
+++ b/python/mrc/_pymrc/src/node.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/operators.cpp
+++ b/python/mrc/_pymrc/src/operators.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/options.cpp
+++ b/python/mrc/_pymrc/src/options.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/pipeline.cpp
+++ b/python/mrc/_pymrc/src/pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/plugins.cpp
+++ b/python/mrc/_pymrc/src/plugins.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/py_segment_module.cpp
+++ b/python/mrc/_pymrc/src/py_segment_module.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/segment_modules.cpp
+++ b/python/mrc/_pymrc/src/segment_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/subscriber.cpp
+++ b/python/mrc/_pymrc/src/subscriber.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/system.cpp
+++ b/python/mrc/_pymrc/src/system.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/tracers.cpp
+++ b/python/mrc/_pymrc/src/tracers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/types.cpp
+++ b/python/mrc/_pymrc/src/types.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utilities/acquire_gil.cpp
+++ b/python/mrc/_pymrc/src/utilities/acquire_gil.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utilities/deserializers.cpp
+++ b/python/mrc/_pymrc/src/utilities/deserializers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utilities/function_wrappers.cpp
+++ b/python/mrc/_pymrc/src/utilities/function_wrappers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utilities/object_cache.cpp
+++ b/python/mrc/_pymrc/src/utilities/object_cache.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utilities/object_wrappers.cpp
+++ b/python/mrc/_pymrc/src/utilities/object_wrappers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utilities/serializers.cpp
+++ b/python/mrc/_pymrc/src/utilities/serializers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/src/watchers.cpp
+++ b/python/mrc/_pymrc/src/watchers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_codable_pyobject.cpp
+++ b/python/mrc/_pymrc/tests/test_codable_pyobject.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_executor.cpp
+++ b/python/mrc/_pymrc/tests/test_executor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_main.cpp
+++ b/python/mrc/_pymrc/tests/test_main.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_object_cache.cpp
+++ b/python/mrc/_pymrc/tests/test_object_cache.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_pickle_wrapper.cpp
+++ b/python/mrc/_pymrc/tests/test_pickle_wrapper.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_pipeline.cpp
+++ b/python/mrc/_pymrc/tests/test_pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_pymrc.hpp
+++ b/python/mrc/_pymrc/tests/test_pymrc.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_serializers.cpp
+++ b/python/mrc/_pymrc/tests/test_serializers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_shmem_wrapper.cpp
+++ b/python/mrc/_pymrc/tests/test_shmem_wrapper.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/benchmarking/trace_statistics.cpp
+++ b/python/mrc/benchmarking/trace_statistics.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/benchmarking/tracers.cpp
+++ b/python/mrc/benchmarking/tracers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/benchmarking/watchers.cpp
+++ b/python/mrc/benchmarking/watchers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/common.cpp
+++ b/python/mrc/core/common.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/executor.cpp
+++ b/python/mrc/core/executor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/logging.cpp
+++ b/python/mrc/core/logging.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/node.cpp
+++ b/python/mrc/core/node.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/operators.cpp
+++ b/python/mrc/core/operators.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/options.cpp
+++ b/python/mrc/core/options.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/pipeline.cpp
+++ b/python/mrc/core/pipeline.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/plugins.cpp
+++ b/python/mrc/core/plugins.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment.cpp
+++ b/python/mrc/core/segment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment/module_definitions/mirror_tap_orchestrator.cpp
+++ b/python/mrc/core/segment/module_definitions/mirror_tap_orchestrator.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment/module_definitions/mirror_tap_orchestrator.hpp
+++ b/python/mrc/core/segment/module_definitions/mirror_tap_orchestrator.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment/module_definitions/segment_module_registry.cpp
+++ b/python/mrc/core/segment/module_definitions/segment_module_registry.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment/module_definitions/segment_module_registry.hpp
+++ b/python/mrc/core/segment/module_definitions/segment_module_registry.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment/module_definitions/segment_modules.cpp
+++ b/python/mrc/core/segment/module_definitions/segment_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/segment/module_definitions/segment_modules.hpp
+++ b/python/mrc/core/segment/module_definitions/segment_modules.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/core/subscriber.cpp
+++ b/python/mrc/core/subscriber.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/tests/sample_modules.cpp
+++ b/python/mrc/tests/sample_modules.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/tests/test_edges.cpp
+++ b/python/mrc/tests/test_edges.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/python/mrc/tests/utils.cpp
+++ b/python/mrc/tests/utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
Prevents the license header from being repeatedly displayed as part of each namespace's documentation.

Discovered this while looking into https://github.com/nv-morpheus/Morpheus/issues/837