### PR TITLE
Use newly built CI images with CUDA 11.8

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -182,6 +182,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         PARALLEL_LEVEL: '10'
       image: ${{ inputs.test_container }}
+      options: "--cap-add=sys_nice --cap-add=sys_ptrace"
     strategy:
       fail-fast: true
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: true
+      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230410
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
     secrets:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,8 +48,8 @@ jobs:
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230315
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230315
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230410
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/ci_pipe.yml
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
+      run_package_conda: true
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230410
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
     secrets:

--- a/ci/scripts/github/build.sh
+++ b/ci/scripts/github/build.sh
@@ -30,13 +30,13 @@ sccache --version
 
 if [[ "${BUILD_CC}" == "gcc" ]]; then
     rapids-logger "Building with GCC"
-    gcc --version
-    g++ --version
+    x86_64-conda-linux-gnu-cc --version
+    x86_64-conda-linux-gnu-c++ --version
     CMAKE_FLAGS="${CMAKE_BUILD_ALL_FEATURES} ${CMAKE_CACHE_FLAGS}"
 elif [[ "${BUILD_CC}" == "gcc-coverage" ]]; then
     rapids-logger "Building with GCC with gcov profile '-g -fprofile-arcs -ftest-coverage"
-    gcc --version
-    g++ --version
+    x86_64-conda-linux-gnu-cc --version
+    x86_64-conda-linux-gnu-c++ --version
     CMAKE_FLAGS="${CMAKE_BUILD_ALL_FEATURES} ${CMAKE_BUILD_WITH_CODECOV} ${CMAKE_CACHE_FLAGS}"
 else
     rapids-logger "Building with Clang"

--- a/ci/scripts/github/build.sh
+++ b/ci/scripts/github/build.sh
@@ -37,6 +37,7 @@ elif [[ "${BUILD_CC}" == "gcc-coverage" ]]; then
     rapids-logger "Building with GCC with gcov profile '-g -fprofile-arcs -ftest-coverage"
     x86_64-conda-linux-gnu-cc --version
     x86_64-conda-linux-gnu-c++ --version
+    x86_64-conda-linux-gnu-gcov --version
     CMAKE_FLAGS="${CMAKE_BUILD_ALL_FEATURES} ${CMAKE_BUILD_WITH_CODECOV} ${CMAKE_CACHE_FLAGS}"
 else
     rapids-logger "Building with Clang"

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -38,5 +38,5 @@ conda info
 
 rapids-logger "Building Conda Package"
 
-# Run the conda build and upload
-${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh upload
+# Run the conda build
+${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -38,5 +38,5 @@ conda info
 
 rapids-logger "Building Conda Package"
 
-# Run the conda build
-${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh
+# Run the conda build and upload
+${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh upload


### PR DESCRIPTION
* Use newly built CI images with CUDA 11.8
* Use the version of gcov installed via conda