### PR TITLE
Dynamically loading `libnvidia-ml.so.1` instead of directly linking

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -132,13 +132,13 @@ jobs:
   test:
     name: Test
     needs: [build]
-    runs-on: [self-hosted, linux, amd64, gpu-v100-525-1]
+    runs-on: [self-hosted, linux, amd64, gpu-v100-latest-1]
     timeout-minutes: 60
     container:
       credentials:
         username: '$oauthtoken'
         password: ${{ secrets.NGC_API_KEY }}
-      image: ${{ inputs.test_container }}
+      image: ${{ inputs.container }}
       options: "--cap-add=sys_nice --cap-add=sys_ptrace"
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
@@ -181,7 +181,7 @@ jobs:
         BUILD_CC: "gcc-coverage"
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         PARALLEL_LEVEL: '10'
-      image: ${{ inputs.test_container }}
+      image: ${{ inputs.container }}
       options: "--cap-add=sys_nice --cap-add=sys_ptrace"
     strategy:
       fail-fast: true

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -28,9 +28,6 @@ on:
       container:
         required: true
         type: string
-      test_container:
-        required: true
-        type: string
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -171,7 +168,7 @@ jobs:
 
   codecov:
     name: Code Coverage
-    runs-on: [self-hosted, linux, amd64, gpu-v100-525-1]
+    runs-on: [self-hosted, linux, amd64, gpu-v100-latest-1]
     timeout-minutes: 60
     container:
       credentials:

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -28,6 +28,9 @@ on:
       container:
         required: true
         type: string
+      test_container:
+        required: true
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -135,7 +138,7 @@ jobs:
       credentials:
         username: '$oauthtoken'
         password: ${{ secrets.NGC_API_KEY }}
-      image: ${{ inputs.container }}
+      image: ${{ inputs.test_container }}
       options: "--cap-add=sys_nice --cap-add=sys_ptrace"
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
@@ -178,7 +181,7 @@ jobs:
         BUILD_CC: "gcc-coverage"
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         PARALLEL_LEVEL: '10'
-      image: ${{ inputs.container }}
+      image: ${{ inputs.test_container }}
       options: "--cap-add=sys_nice --cap-add=sys_ptrace"
     strategy:
       fail-fast: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-driver-230410
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,8 @@ jobs:
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-230412
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230412
+      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230412
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,8 +48,7 @@ jobs:
     with:
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
       run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
-      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
-      test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230410
+      container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-230412
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,13 @@ ENV CMAKE_CUDA_COMPILER_LAUNCHER=
 ENV CMAKE_CXX_COMPILER_LAUNCHER=
 ENV CMAKE_C_COMPILER_LAUNCHER=
 
+# ============ build ==================
+FROM base as build
+
+# Add any build only dependencies here. For now there is none but we need the
+# target to get the CI runner build scripts to work
+
 # ============ test ==================
-# Specific target for the CI test runner
 FROM base as test
 
 # Add any test only dependencies here. For now there is none but we need the

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,18 +55,8 @@ ENV CMAKE_CUDA_COMPILER_LAUNCHER=
 ENV CMAKE_CXX_COMPILER_LAUNCHER=
 ENV CMAKE_C_COMPILER_LAUNCHER=
 
-# ============ driver ==================
-FROM base as driver
-
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt update && \
-    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC \
-    apt install --no-install-recommends -y \
-    libnvidia-compute-525 \
-    && \
-    rm -rf /var/lib/apt/lists/*
-
 # ============ test ==================
+# Specific target for the CI test runner
 FROM base as test
 
 # Add any test only dependencies here. For now there is none but we need the

--- a/cpp/mrc/CMakeLists.txt
+++ b/cpp/mrc/CMakeLists.txt
@@ -166,7 +166,6 @@ target_link_libraries(libmrc
     mrc_protos
     mrc_architect_protos
     rmm::rmm
-    CUDA::nvml
     CUDA::cudart
     rxcpp::rxcpp
     glog::glog
@@ -180,8 +179,8 @@ target_link_libraries(libmrc
   PRIVATE
     hwloc::hwloc
     prometheus-cpp::core # private in MR !199
-    ucx::ucs
     ucx::ucp
+    ucx::ucs
 )
 
 target_include_directories(libmrc
@@ -205,10 +204,6 @@ endif()
 target_compile_features(libmrc PUBLIC cxx_std_20)
 
 set_target_properties(libmrc PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
-
-# Finally, set the install RPATH to include the stubs folder for CUDA::nvml. If thats made private, this can be removed
-set_target_properties(libmrc PROPERTIES INSTALL_RPATH
-    "${CMAKE_INSTALL_PREFIX}/lib:\$ORIGIN:${CMAKE_INSTALL_PREFIX}/lib/stubs")
 
 # ##################################################################################################
 # - install targets --------------------------------------------------------------------------------
@@ -277,4 +272,3 @@ rapids_export(BUILD ${PROJECT_NAME}
   DOCUMENTATION doc_string
   FINAL_CODE_BLOCK code_string
 )
-

--- a/cpp/mrc/src/internal/system/device_info.cpp
+++ b/cpp/mrc/src/internal/system/device_info.cpp
@@ -20,42 +20,127 @@
 #include "mrc/cuda/common.hpp"  // IWYU pragma: associated
 
 #include <cuda_runtime.h>
+#include <dlfcn.h>
 #include <glog/logging.h>
+#include <hwloc.h>
+#include <hwloc/linux.h>
 #include <nvml.h>
 
 #include <array>
+#include <cerrno>
 #include <cstddef>
+#include <memory>
 #include <ostream>
 #include <set>
+#include <stdexcept>
 #include <string>
 
 #define TEST_BIT(_n, _p) (_n & (1UL << _p))
 
-#define MRC_CHECK_NVML(expression)                                    \
-    {                                                                 \
-        auto status = (expression);                                   \
-        if (status != NVML_SUCCESS)                                   \
-        {                                                             \
-            LOG(FATAL) << "NVML failed: " << nvmlErrorString(status); \
-        }                                                             \
+#define MRC_CHECK_NVML(expression)                                                           \
+    {                                                                                        \
+        auto __status = (expression);                                                        \
+        if (__status != NVML_SUCCESS)                                                        \
+        {                                                                                    \
+            LOG(FATAL) << "NVML failed running '" << #expression                             \
+                       << "'. Error msg: " << NvmlState::handle().nvmlErrorString(__status); \
+        }                                                                                    \
     }
 
 namespace {
+
+#define LOAD_NVTX_SYM(dll_ptr, function_var)                                                        \
+    function_var = reinterpret_cast<decltype(function_var)>(dlsym(dll_ptr, #function_var));         \
+    if (function_var == nullptr)                                                                    \
+    {                                                                                               \
+        throw std::runtime_error("Failed to load symbol " #function_var " from libnvidia-ml.so.1"); \
+    }
+
+struct NvmlHandle
+{
+    NvmlHandle()
+    {
+        // First, try to open the library dynamically
+        m_nvml_dll = dlopen("libnvidia-ml.so.1", RTLD_LOCAL | RTLD_LAZY);
+
+        if (m_nvml_dll == nullptr)
+        {
+            throw std::runtime_error("Could not open libnvidia-ml.so.1");
+        }
+
+        // Now load the symbols. Keep init first
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlInit_v2);
+
+        // Keep the rest of the functions sorted. Must match list of functions below!
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetCount_v2);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetHandleByIndex_v2);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetMemoryInfo);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetMigMode);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetName);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetPciInfo_v3);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetPowerManagementLimit);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetPowerUsage);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetTotalEnergyConsumption);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlDeviceGetUUID);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlErrorString);
+        LOAD_NVTX_SYM(m_nvml_dll, nvmlShutdown);
+    }
+
+    ~NvmlHandle()
+    {
+        if (m_nvml_dll != nullptr)
+        {
+            dlclose(m_nvml_dll);
+        }
+    }
+
+    // NOLINTBEGIN(readability-identifier-naming)
+    // Keep the init function up top
+    decltype(&::nvmlInit_v2) nvmlInit_v2{nullptr};
+
+    // Keep the rest of the functions sorted
+    decltype(&::nvmlDeviceGetCount_v2) nvmlDeviceGetCount_v2{nullptr};
+    decltype(&::nvmlDeviceGetHandleByIndex_v2) nvmlDeviceGetHandleByIndex_v2{nullptr};
+    decltype(&::nvmlDeviceGetMemoryInfo) nvmlDeviceGetMemoryInfo{nullptr};
+    decltype(&::nvmlDeviceGetMigMode) nvmlDeviceGetMigMode{nullptr};
+    decltype(&::nvmlDeviceGetName) nvmlDeviceGetName{nullptr};
+    decltype(&::nvmlDeviceGetPciInfo_v3) nvmlDeviceGetPciInfo_v3{nullptr};
+    decltype(&::nvmlDeviceGetPowerManagementLimit) nvmlDeviceGetPowerManagementLimit{nullptr};
+    decltype(&::nvmlDeviceGetPowerUsage) nvmlDeviceGetPowerUsage{nullptr};
+    decltype(&::nvmlDeviceGetTotalEnergyConsumption) nvmlDeviceGetTotalEnergyConsumption{nullptr};
+    decltype(&::nvmlDeviceGetUUID) nvmlDeviceGetUUID{nullptr};
+    decltype(&::nvmlErrorString) nvmlErrorString{nullptr};
+    decltype(&::nvmlShutdown) nvmlShutdown{nullptr};
+    // NOLINTEND(readability-identifier-naming)
+
+  private:
+    void* m_nvml_dll{nullptr};
+};
+
 struct NvmlState
 {
     NvmlState()
     {
-        auto nvml_status = nvmlInit_v2();
+        try
+        {
+            m_nvml_handle = std::make_unique<NvmlHandle>();
+        } catch (std::runtime_error e)
+        {
+            LOG(WARNING) << "NVML: " << e.what() << ". Setting DeviceCount to 0, CUDA will not be initialized";
+            return;
+        }
+
+        auto nvml_status = m_nvml_handle->nvmlInit_v2();
         if (nvml_status != NVML_SUCCESS)
         {
-            LOG(WARNING) << "NVML: Error initializing due to '" << nvmlErrorString(nvml_status)
+            LOG(WARNING) << "NVML: Error initializing due to '" << m_nvml_handle->nvmlErrorString(nvml_status)
                          << "'. Setting DeviceCount to 0, CUDA will not be initialized";
             return;
         }
 
         unsigned int visible_devices = 0;
 
-        CHECK_EQ(nvmlDeviceGetCount_v2(&visible_devices), NVML_SUCCESS);
+        MRC_CHECK_NVML(m_nvml_handle->nvmlDeviceGetCount_v2(&visible_devices));
 
         for (decltype(visible_devices) i = 0; i < visible_devices; i++)
         {
@@ -63,15 +148,15 @@ struct NvmlState
             unsigned int current_mig_mode;
             unsigned int pending_mig_mode;
 
-            auto device_status = nvmlDeviceGetHandleByIndex_v2(i, &device_handle);
+            auto device_status = m_nvml_handle->nvmlDeviceGetHandleByIndex_v2(i, &device_handle);
             if (device_status != NVML_SUCCESS)
             {
-                LOG(WARNING) << "NVML: " << nvmlErrorString(device_status) << "; device with index " << i
+                LOG(WARNING) << "NVML: " << m_nvml_handle->nvmlErrorString(device_status) << "; device with index " << i
                              << " will be ignored";
                 continue;
             }
 
-            auto mig_status = nvmlDeviceGetMigMode(device_handle, &current_mig_mode, &pending_mig_mode);
+            auto mig_status = m_nvml_handle->nvmlDeviceGetMigMode(device_handle, &current_mig_mode, &pending_mig_mode);
             if (mig_status == NVML_SUCCESS &&
                 (current_mig_mode == NVML_DEVICE_MIG_ENABLE || pending_mig_mode == NVML_DEVICE_MIG_ENABLE))
             {
@@ -102,7 +187,12 @@ struct NvmlState
     }
     ~NvmlState()
     {
-        CHECK_EQ(nvmlShutdown(), NVML_SUCCESS) << "Failed to Shutdown NVML";
+        MRC_CHECK_NVML(m_nvml_handle->nvmlShutdown());
+    }
+
+    NvmlHandle& get_handle()
+    {
+        return *m_nvml_handle;
     }
 
     const std::set<unsigned int>& accessible_nvml_device_indexes() const
@@ -121,6 +211,11 @@ struct NvmlState
         return state;
     }
 
+    static NvmlHandle& handle()
+    {
+        return NvmlState::instance().get_handle();
+    }
+
   private:
     // this object can also hold the list of device handles that we have access to.
     // - nvmlDeviceGetCount_v2 - will tell us the total number of devices we have access to, i.e. the range of [0, N)
@@ -130,21 +225,23 @@ struct NvmlState
     std::set<unsigned int> m_accessible_indexes;
 
     bool m_using_mig{false};
+
+    std::unique_ptr<NvmlHandle> m_nvml_handle;
 };
 
 }  // namespace
 
 namespace mrc::internal::system {
 
-nvmlDevice_t DeviceInfo::GetHandleById(unsigned int device_id)
+nvmlDevice_t get_handle_by_id(unsigned int device_id)
 {
     nvmlDevice_t handle;
-    CHECK_EQ(nvmlDeviceGetHandleByIndex(device_id, &handle), NVML_SUCCESS);
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetHandleByIndex_v2(device_id, &handle));
     return handle;
 }
 
 /*
-cpu_set DeviceInfo::Affinity(int device_id)
+cpu_set DeviceInfo::Affinity(unsigned int device_id)
 {
     nvmlDevice_t gpu       = DeviceInfo::GetHandleById(device_id);
     unsigned long cpu_mask = 0;
@@ -166,42 +263,7 @@ cpu_set DeviceInfo::Affinity(int device_id)
 }
 */
 
-std::size_t DeviceInfo::Alignment()
-{
-    struct cudaDeviceProp properties;
-    MRC_CHECK_CUDA(cudaGetDeviceProperties(&properties, 0));
-    return properties.textureAlignment;
-}
-
-double DeviceInfo::PowerUsage(int device_id)
-{
-    unsigned int power;
-    CHECK_EQ(nvmlDeviceGetPowerUsage(DeviceInfo::GetHandleById(device_id), &power), NVML_SUCCESS);
-    return static_cast<double>(power) * 0.001;
-}
-
-double DeviceInfo::PowerLimit(int device_id)
-{
-    unsigned int limit;
-    CHECK_EQ(nvmlDeviceGetPowerManagementLimit(DeviceInfo::GetHandleById(device_id), &limit), NVML_SUCCESS);
-    return static_cast<double>(limit) * 0.001;
-}
-
-std::string DeviceInfo::UUID(int device_id)
-{
-    std::array<char, 256> buffer;
-    CHECK_EQ(nvmlDeviceGetUUID(DeviceInfo::GetHandleById(device_id), buffer.data(), 256), NVML_SUCCESS);
-    return buffer.data();
-}
-
-std::string DeviceInfo::PCIeBusID(int device_id)
-{
-    nvmlPciInfo_t info;
-    CHECK_EQ(nvmlDeviceGetPciInfo_v3(DeviceInfo::GetHandleById(device_id), &info), NVML_SUCCESS);
-    return info.busId;
-}
-
-std::size_t DeviceInfo::AccessibleDevices()
+std::size_t DeviceInfo::AccessibleDeviceCount()
 {
     return NvmlState::instance().accessible_nvml_device_indexes().size();
 }
@@ -211,17 +273,91 @@ std::set<unsigned int> DeviceInfo::AccessibleDeviceIndexes()
     return NvmlState::instance().accessible_nvml_device_indexes();
 }
 
-nvmlMemory_t DeviceInfo::MemoryInfo(int device_id)
+std::size_t DeviceInfo::Alignment()
 {
-    nvmlMemory_t info;
-    MRC_CHECK_NVML(nvmlDeviceGetMemoryInfo(DeviceInfo::GetHandleById(device_id), &info));
-    return info;
+    struct cudaDeviceProp properties;
+    MRC_CHECK_CUDA(cudaGetDeviceProperties(&properties, 0));
+    return properties.textureAlignment;
 }
 
-std::string DeviceInfo::Name(int device_id)
+unsigned long long DeviceInfo::DeviceTotalMemory(unsigned int device_id)
+{
+    nvmlMemory_t info;
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetMemoryInfo(get_handle_by_id(device_id), &info));
+    return info.total;
+}
+
+auto DeviceInfo::EnergyConsumption(unsigned int device_id) -> double
+{
+    unsigned long long energy;
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetTotalEnergyConsumption(get_handle_by_id(device_id), &energy));
+    return static_cast<double>(energy) * 0.001;
+}
+
+// This function is taken directly from `hwloc/nvml.h` and updated to use NvmlHandle instead
+auto DeviceInfo::GetDeviceCpuset(hwloc_topology_t topology, unsigned int device_id, hwloc_cpuset_t set) -> int
+{
+/* If we're on Linux, use the sysfs mechanism to get the local cpus */
+#define HWLOC_NVML_DEVICE_SYSFS_PATH_MAX 128
+    std::array<char, HWLOC_NVML_DEVICE_SYSFS_PATH_MAX> path;
+    nvmlReturn_t nvres;
+    nvmlPciInfo_t pci;
+
+    if (hwloc_topology_is_thissystem(topology) == 0)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    nvres = NvmlState::handle().nvmlDeviceGetPciInfo_v3(get_handle_by_id(device_id), &pci);
+    if (NVML_SUCCESS != nvres)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    sprintf(path.data(), "/sys/bus/pci/devices/%04x:%02x:%02x.0/local_cpus", pci.domain, pci.bus, pci.device);
+
+    if (hwloc_linux_read_path_as_cpumask(path.data(), set) < 0 || (hwloc_bitmap_iszero(set) != 0))
+    {
+        hwloc_bitmap_copy(set, hwloc_topology_get_complete_cpuset(topology));
+    }
+
+    return 0;
+}
+
+std::string DeviceInfo::Name(unsigned int device_id)
 {
     std::array<char, 256> buffer;
-    CHECK_EQ(nvmlDeviceGetName(DeviceInfo::GetHandleById(device_id), buffer.data(), 256), NVML_SUCCESS);
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetName(get_handle_by_id(device_id), buffer.data(), 256));
+    return buffer.data();
+}
+
+std::string DeviceInfo::PCIeBusID(unsigned int device_id)
+{
+    nvmlPciInfo_t info;
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetPciInfo_v3(get_handle_by_id(device_id), &info));
+    return info.busId;
+}
+
+double DeviceInfo::PowerLimit(unsigned int device_id)
+{
+    unsigned int limit;
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetPowerManagementLimit(get_handle_by_id(device_id), &limit));
+    return static_cast<double>(limit) * 0.001;
+}
+
+double DeviceInfo::PowerUsage(unsigned int device_id)
+{
+    unsigned int power;
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetPowerUsage(get_handle_by_id(device_id), &power));
+    return static_cast<double>(power) * 0.001;
+}
+
+std::string DeviceInfo::UUID(unsigned int device_id)
+{
+    std::array<char, 256> buffer;
+    MRC_CHECK_NVML(NvmlState::handle().nvmlDeviceGetUUID(get_handle_by_id(device_id), buffer.data(), 256));
     return buffer.data();
 }
 

--- a/cpp/mrc/src/internal/system/device_info.hpp
+++ b/cpp/mrc/src/internal/system/device_info.hpp
@@ -17,28 +17,35 @@
 
 #pragma once
 
-#include <nvml.h>
-
 #include <cstddef>
 #include <set>
 #include <string>
+
+// DO NOT INCLUDE <nvml.h>!!!!
+
+// NOLINTBEGIN(readability-identifier-naming)
+using hwloc_cpuset_t   = struct hwloc_bitmap_s*;
+using hwloc_topology_t = struct hwloc_topology*;
+using nvmlDevice_t     = struct nvmlDevice_st*;
+// NOLINTEND(readability-identifier-naming)
 
 namespace mrc::internal::system {
 
 struct DeviceInfo
 {
-    static nvmlDevice_t GetHandleById(unsigned int device_id);  // NOLINT
-    // static auto Affinity(int device_id) -> cpu_set;
-    static auto Alignment() -> std::size_t;                           // NOLINT
-    static auto EnergyConsumption(int device_id) -> double;           // NOLINT
-    static auto MemoryInfo(int device_id) -> nvmlMemory_t;            // NOLINT
-    static auto PowerUsage(int device_id) -> double;                  // NOLINT
-    static auto PowerLimit(int device_id) -> double;                  // NOLINT
-    static auto UUID(int device_id) -> std::string;                   // NOLINT
-    static auto PCIeBusID(int device_id) -> std::string;              // NOLINT
-    static auto Name(int) -> std::string;                             // NOLINT
-    static auto AccessibleDeviceIndexes() -> std::set<unsigned int>;  // NOLINT
-    static auto AccessibleDevices() -> std::size_t;                   // NOLINT
+    // NOLINTBEGIN(readability-identifier-naming)
+    static auto AccessibleDeviceCount() -> std::size_t;
+    static auto AccessibleDeviceIndexes() -> std::set<unsigned int>;
+    static auto Alignment() -> std::size_t;
+    static auto DeviceTotalMemory(unsigned int device_id) -> unsigned long long;
+    static auto EnergyConsumption(unsigned int device_id) -> double;
+    static auto GetDeviceCpuset(hwloc_topology_t topology, unsigned int device_id, hwloc_cpuset_t set) -> int;
+    static auto Name(unsigned int device_id) -> std::string;
+    static auto PCIeBusID(unsigned int device_id) -> std::string;
+    static auto PowerLimit(unsigned int device_id) -> double;
+    static auto PowerUsage(unsigned int device_id) -> double;
+    static auto UUID(unsigned int device_id) -> std::string;
+    // NOLINTEND(readability-identifier-naming)
 };
 
 }  // namespace mrc::internal::system

--- a/cpp/mrc/src/internal/system/topology.cpp
+++ b/cpp/mrc/src/internal/system/topology.cpp
@@ -29,8 +29,6 @@
 #include <glog/logging.h>
 #include <hwloc.h>
 #include <hwloc/bitmap.h>
-#include <hwloc/nvml.h>
-#include <nvml.h>
 
 #include <cstdio>
 #include <cstring>
@@ -81,13 +79,12 @@ std::shared_ptr<Topology> Topology::Create(const TopologyOptions& options)
     {
         GpuInfo info;
 
-        auto* device           = DeviceInfo::GetHandleById(i);
         info.m_name            = DeviceInfo::Name(i);
         info.m_uuid            = DeviceInfo::UUID(i);
         info.m_pcie_bus_id     = DeviceInfo::PCIeBusID(i);
-        info.m_memory_capacity = DeviceInfo::MemoryInfo(i).total;
-        auto rc                = hwloc_nvml_get_device_cpuset(system_topology, device, &info.m_cpu_set.bitmap());
-        CHECK_EQ(rc, 0);
+        info.m_memory_capacity = DeviceInfo::DeviceTotalMemory(i);
+        CHECK_EQ(DeviceInfo::GetDeviceCpuset(system_topology, i, &info.m_cpu_set.bitmap()), 0) << "Invalid GPU device "
+                                                                                                  "CPU set";
 
         auto v        = info.cpu_set().vec();
         info.m_cpustr = print_ranges(find_ranges(v));

--- a/cpp/mrc/src/tests/test_topology.cpp
+++ b/cpp/mrc/src/tests/test_topology.cpp
@@ -26,7 +26,6 @@
 #include <gtest/gtest.h>
 #include <hwloc.h>
 #include <hwloc/bitmap.h>
-#include <hwloc/nvml.h>
 
 #include <cstdint>
 #include <cstdio>
@@ -142,10 +141,8 @@ TEST_F(TestTopology, HwlocDev)
     hwloc_topology_t topology;
     hwloc_topology_init(&topology);
 
-    auto* device  = internal::system::DeviceInfo::GetHandleById(0);
     auto* cpu_set = hwloc_bitmap_alloc();
-    auto rc       = hwloc_nvml_get_device_cpuset(topology, device, cpu_set);
-    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(mrc::internal::system::DeviceInfo::GetDeviceCpuset(topology, 0, cpu_set), 0);
 
     char* cpuset_string = nullptr;
     hwloc_bitmap_asprintf(&cpuset_string, cpu_set);


### PR DESCRIPTION
Currently, we install the driver into one of the CI images to allow for stub generation during compilation. This was needed because `device_info.cpp` linked directly against `CUDA::nvml`. This caused a link dependency on a driver library which is problematic when building with CPU-only docker images.

Instead, we dynamically load `libnvidia-ml.so.1` (appending the `.so.1` to avoid collisions with the stub file `libnvidia-ml.so`) and the necessary functions at runtime. If the library is not found, using a GPU will be disabled. This allows loading of the library for stub generation without needing a GPU.