### PR TITLE
Adding an `update-version.sh` script and CI check to keep versions up to date

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Usage
+# Either supply full versions:
+#    `bash update-version.sh <current_version> <new_version>`
+#    Format is YY.MM.PP - no leading 'v' or trailing 'a'
+# Or no versions:
+#    `bash update-version.sh`
+
+set -e
+
+# If the user has not supplied the versions, determine them from the git tags
+if [[ "$#" -ne 2 ]]; then
+   echo "No versions were provided. Using last 2 git tags to determined current and next version"
+
+   # Current version comes from the previous alpha tag
+   CURRENT_FULL_VERSION=$(git tag --merged HEAD --list 'v*' | sort --version-sort | tail -n 2 | head -n 1 | tr -d 'va')
+   # Next version comes from the latest alpha tag
+   NEXT_FULL_VERSION=$(git tag --merged HEAD --list 'v*' | sort --version-sort | tail -n 1 | tr -d 'va')
+else
+   # User has supplied current and next arguments
+   CURRENT_FULL_VERSION=$1
+   NEXT_FULL_VERSION=$2
+fi
+
+CURRENT_MAJOR=$(echo ${CURRENT_FULL_VERSION} | awk '{split($0, a, "."); print a[1]}')
+CURRENT_MINOR=$(echo ${CURRENT_FULL_VERSION} | awk '{split($0, a, "."); print a[2]}')
+CURRENT_PATCH=$(echo ${CURRENT_FULL_VERSION} | awk '{split($0, a, "."); print a[3]}')
+CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
+
+NEXT_MAJOR=$(echo ${NEXT_FULL_VERSION} | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo ${NEXT_FULL_VERSION} | awk '{split($0, a, "."); print a[2]}')
+NEXT_PATCH=$(echo ${NEXT_FULL_VERSION} | awk '{split($0, a, "."); print a[3]}')
+NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
+
+# Need to distutils-normalize the versions for some use cases
+CURRENT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${CURRENT_SHORT_TAG}'))")
+NEXT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_SHORT_TAG}'))")
+
+echo "Preparing release $CURRENT_FULL_VERSION (PEP ${CURRENT_SHORT_TAG_PEP440}) => $NEXT_FULL_VERSION (PEP ${NEXT_SHORT_TAG_PEP440})"
+
+# Inplace sed replace; workaround for Linux and Mac
+function sed_runner() {
+    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+}
+
+# .gitmodules
+git submodule set-branch -b branch-${NEXT_SHORT_TAG} morpheus_utils
+
+# Root CMakeLists.txt
+sed_runner 's/'"VERSION ${CURRENT_FULL_VERSION}.*"'/'"VERSION ${NEXT_FULL_VERSION}"'/g' CMakeLists.txt
+
+# Quickstart CMakeLists.txt
+sed_runner 's/'"VERSION ${CURRENT_FULL_VERSION}.*"'/'"VERSION ${NEXT_FULL_VERSION}"'/g' docs/quickstart/CMakeLists.txt
+
+# Quickstart environment file
+sed_runner "s/mrc=${CURRENT_SHORT_TAG}/mrc=${NEXT_SHORT_TAG}/g" docs/quickstart/environment_cpp.yml

--- a/ci/scripts/github/checks.sh
+++ b/ci/scripts/github/checks.sh
@@ -29,6 +29,9 @@ cmake -B build -G Ninja ${CMAKE_BUILD_ALL_FEATURES} .
 rapids-logger "Building targets that generate source code"
 cmake --build build --target mrc_style_checks --parallel ${PARALLEL_LEVEL}
 
+rapids-logger "Checking versions"
+${MRC_ROOT}/ci/scripts/version_checks.sh
+
 rapids-logger "Running C++ style checks"
 ${MRC_ROOT}/ci/scripts/cpp_checks.sh
 

--- a/ci/scripts/version_checks.sh
+++ b/ci/scripts/version_checks.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source ${SCRIPT_DIR}/common.sh
+
+# Run the update version script
+UPDATE_VERSION_OUTPUT=`${MRC_ROOT}/ci/release/update-version.sh`
+
+# If any diffs were found, the versions were out of date
+VERSIONS_OUT_OF_DATE=$(git diff --name-only)
+
+if [[ "${VERSIONS_OUT_OF_DATE}" != "" ]]; then
+   echo -e "\n\n>>>> FAILED: version check; begin output\n\n"
+   echo -e "${UPDATE_VERSION_OUTPUT}"
+   echo -e "\n\nThe following files have out of date versions:"
+   echo -e "${VERSIONS_OUT_OF_DATE}"
+   echo -e "\n\n>>>> FAILED: version check; end output\n\n" \
+           "To update the versions, run the following and commit the results:\n" \
+           "   ./ci/release/update-version.sh\n\n"
+   exit 1
+fi

--- a/docs/quickstart/CMakeLists.txt
+++ b/docs/quickstart/CMakeLists.txt
@@ -28,7 +28,7 @@ list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../external/utili
 include(morpheus_utils/load)
 
 project(mrc-quickstart
-  VERSION 23.07
+  VERSION 23.07.00
   LANGUAGES C CXX
 )
 


### PR DESCRIPTION
This adds a new script `./ci/release/update-version.sh` which will update all necessary versions used in the repo. This script should be run immediately after creating a new branch and tagging with the alpha tag.

This also runs the script in CI to ensure that no version is ever out of date.