### PR TITLE
Use ARC V2 self-hosted runners for GPU jobs

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -132,7 +132,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    runs-on: [self-hosted, linux, amd64, gpu-v100-latest-1]
+    runs-on: linux-amd64-gpu-v100-latest-1
     timeout-minutes: 60
     container:
       credentials:
@@ -171,7 +171,7 @@ jobs:
 
   codecov:
     name: Code Coverage
-    runs-on: [self-hosted, linux, amd64, gpu-v100-latest-1]
+    runs-on: linux-amd64-gpu-v100-latest-1
     timeout-minutes: 60
     container:
       credentials:


### PR DESCRIPTION
This PR is updating the runner labels to use ARC V2 self-hosted runners for GPU jobs. This is needed to resolve the auto-scalling issues.