### PR TITLE
Create label-external-issues.yml

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Triage outside issues
+
+on:
+  issues:
+    types:
+      - opened
+      
+env:
+  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
+
+jobs:
+  Label-Issue:
+    runs-on: ubuntu-latest
+    # Only run if the issue author is not part of NV-Morpheus
+    if: ${{ ! contains(fromJSON('["OWNER", "MEMBER", "CONTRIBUTOR"]'), github.event.issue.author_association)}}
+    steps: 
+      - name: add-triage-label
+        run: |
+          issue_url=${{ github.event.issue.html_url }}
+          gh issue edit ${issue_url} --add-label "Needs Triage"
+      
+      - name: add-comment-to-issue
+        run: |
+           issue_url=${{ github.event.issue.html_url }}
+           author=${{ github.event.issue.user.login }}
+           echo ${author}
+           gh issue comment ${issue_url} --body "Hi @${author}!
+             
+             Thanks for submitting this issue - our team has been notified and we'll get back to you as soon as we can!
+             In the meantime, feel free to add any relevant information to this issue."


### PR DESCRIPTION
## Description
This PR adds in the external issue labeler/commenter GHA. The action is the same as in nv-morpheus/morpheus

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
