### PR TITLE
Adding Combination Operators `Zip`, `CombineLatest`, `WithLatestFrom`

### DIFF
--- a/cpp/mrc/include/mrc/channel/status.hpp
+++ b/cpp/mrc/include/mrc/channel/status.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <ostream>
+
 namespace mrc::channel {
 
 enum class Status
@@ -29,4 +31,25 @@ enum class Status
     error
 };
 
+static inline std::ostream& operator<<(std::ostream& os, const Status& s)
+{
+    switch (s)
+    {
+    case Status::success:
+        return os << "success";
+    case Status::empty:
+        return os << "empty";
+    case Status::full:
+        return os << "full";
+    case Status::closed:
+        return os << "closed";
+    case Status::timeout:
+        return os << "timeout";
+    case Status::error:
+        return os << "error";
+    default:
+        throw std::logic_error("Unsupported channel::Status enum. Was a new value added recently?");
+    }
 }
+
+}  // namespace mrc::channel

--- a/cpp/mrc/include/mrc/core/utils.hpp
+++ b/cpp/mrc/include/mrc/core/utils.hpp
@@ -19,6 +19,8 @@
 
 #include "mrc/utils/macros.hpp"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <exception>
 #include <map>
@@ -54,47 +56,47 @@ std::set<KeyT> extract_keys(const std::map<KeyT, ValT>& stdmap)
 }
 
 // RAII will execute a function when destroyed.
-template <typename FunctionT>
 class Unwinder
 {
   public:
+    explicit Unwinder(std::function<void()> unwind_fn) : m_unwind_fn(std::move(unwind_fn)) {}
+
     ~Unwinder()
     {
-        if (!!m_function)
+        if (!!m_unwind_fn)
         {
             try
             {
-                (*m_function)();
+                m_unwind_fn();
             } catch (...)
             {
+                LOG(ERROR) << "Fatal error during unwinder function";
                 std::terminate();
             }
         }
     }
 
-    explicit Unwinder(FunctionT* function_arg) : m_function(function_arg) {}
-
     void detach()
     {
-        m_function = nullptr;
+        m_unwind_fn = nullptr;
     }
 
     Unwinder()                           = delete;
     Unwinder(const Unwinder&)            = delete;
     Unwinder& operator=(const Unwinder&) = delete;
 
+    static Unwinder create(std::function<void()> unwind_fn)
+    {
+        return Unwinder(std::move(unwind_fn));
+    }
+
   private:
-    FunctionT* m_function;
+    std::function<void()> m_unwind_fn;
 };
 
-#define MRC_UNWIND(var_name, function) MRC_UNWIND_EXPLICIT(uw_func_##var_name, var_name, function)
+#define MRC_UNWIND(unwinder_name, function) mrc::Unwinder unwinder_name(function);
 
-#define MRC_UNWIND_AUTO(function) \
-    MRC_UNWIND_EXPLICIT(MRC_UNIQUE_VAR_NAME(uw_func_), MRC_UNIQUE_VAR_NAME(un_obj_), function)
-
-#define MRC_UNWIND_EXPLICIT(function_name, unwinder_name, function) \
-    auto function_name = (function);                                \
-    mrc::Unwinder<decltype(function_name)> unwinder_name(std::addressof(function_name))
+#define MRC_UNWIND_AUTO(function) MRC_UNWIND(MRC_UNIQUE_VAR_NAME(__un_obj_), function)
 
 template <typename T>
 std::pair<std::set<T>, std::set<T>> set_compare(const std::set<T>& cur_set, const std::set<T>& new_set)

--- a/cpp/mrc/include/mrc/edge/edge_channel.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_channel.hpp
@@ -20,6 +20,7 @@
 #include "mrc/edge/edge_readable.hpp"
 #include "mrc/edge/edge_writable.hpp"
 #include "mrc/edge/forward.hpp"
+#include "mrc/utils/macros.hpp"
 
 #include <memory>
 
@@ -89,6 +90,24 @@ class EdgeChannel
     {
         CHECK(m_channel) << "Cannot create an EdgeChannel from an empty pointer";
     }
+
+    EdgeChannel(EdgeChannel&& other) : m_channel(std::move(other.m_channel)) {}
+
+    EdgeChannel& operator=(EdgeChannel&& other)
+    {
+        if (this == &other)
+        {
+            return *this;
+        }
+
+        m_channel = std::move(other.m_channel);
+
+        return *this;
+    }
+
+    // This should not be copyable because it requires passing in a unique_ptr
+    DELETE_COPYABILITY(EdgeChannel);
+
     virtual ~EdgeChannel() = default;
 
     [[nodiscard]] std::shared_ptr<EdgeChannelReader<T>> get_reader() const

--- a/cpp/mrc/include/mrc/node/operators/combine_latest.hpp
+++ b/cpp/mrc/include/mrc/node/operators/combine_latest.hpp
@@ -31,90 +31,19 @@
 
 namespace mrc::node {
 
-// template <typename... TypesT>
-// class ParameterPackIndexer
-// {
-//   public:
-//     ParameterPackIndexer(TypesT... ts) : ParameterPackIndexer(std::make_index_sequence<sizeof...(TypesT)>{}, ts...)
-//     {}
-
-//     std::tuple<std::tuple<TypesT, std::size_t>...> tup;
-
-//   private:
-//     template <std::size_t... Is>
-//     ParameterPackIndexer(std::index_sequence<Is...> const& /*unused*/, TypesT... ts) : tup{std::make_tuple(ts,
-//     Is)...}
-//     {}
-// };
-
-// template <typename TargetT, typename ListHeadT, typename... ListTailsT>
-// constexpr size_t getTypeIndexInTemplateList()
-// {
-//     if constexpr (std::is_same<TargetT, ListHeadT>::value)
-//     {
-//         return 0;
-//     }
-//     else
-//     {
-//         return 1 + getTypeIndexInTemplateList<TargetT, ListTailsT...>();
-//     }
-// }
-
-namespace detail {
-struct Surely
+template <typename StdTuple, std::size_t... Is>
+auto surely(const StdTuple& stdTuple, std::index_sequence<Is...>)
 {
-    template <class... T>
-    auto operator()(const T&... t) const -> decltype(std::make_tuple(t.value()...))
-    {
-        return std::make_tuple(t.value()...);
-    }
-};
-}  // namespace detail
-
-// template <class... T>
-// inline auto surely(const std::tuple<T...>& tpl) -> decltype(rxcpp::util::apply(tpl, detail::surely()))
-// {
-//     return rxcpp::util::apply(tpl, detail::surely());
-// }
-
-template <class... T>
-inline auto surely2(const std::tuple<T...>& tpl)
-{
-    return std::apply([](auto... args) {
-        return std::make_tuple(args.value()...);
-    });
+    return std::tuple<typename std::tuple_element_t<Is, std::decay_t<StdTuple>>::value_type...>(
+        (std::get<Is>(stdTuple).value())...);
 }
 
-// template <typename... TypesT>
-// static auto surely2(const std::tuple<TypesT...>& tpl, std::index_sequence<Is...>)
-// {
-//     return std::make_tuple(std::make_shared<Upstream<Is>>(*self)...);
-// }
-
-// template <size_t i, typename T>
-// struct IndexTypePair
-// {
-//     static constexpr size_t index{i};
-//     using Type = T;
-// };
-
-// template <typename... T>
-// struct make_index_type_tuple_helper
-// {
-//     template <typename V>
-//     struct idx;
-
-//     template <size_t... Indices>
-//     struct idx<std::index_sequence<Indices...>>
-//     {
-//         using tuple_type = std::tuple<IndexTypePair<Indices, T>...>;
-//     };
-
-//     using tuple_type = typename idx<std::make_index_sequence<sizeof...(T)>>::tuple_type;
-// };
-
-// template <typename... T>
-// using make_index_type_tuple = typename make_index_type_tuple_helper<T...>::tuple_type;
+// Converts a std::tuple<std::optional<T1>, std::optional<T2>, ...> to std::tuple<T1, T1, ...>
+template <typename StdTuple>
+auto surely(const StdTuple& stdTuple)
+{
+    return surely(stdTuple, std::make_index_sequence<std::tuple_size<std::decay_t<StdTuple>>::value>());
+}
 
 template <typename... TypesT>
 class CombineLatest : public WritableAcceptor<std::tuple<TypesT...>>
@@ -128,9 +57,7 @@ class CombineLatest : public WritableAcceptor<std::tuple<TypesT...>>
   public:
     CombineLatest() :
       m_upstream_holders(build_ingress(const_cast<CombineLatest*>(this), std::index_sequence_for<TypesT...>{}))
-    {
-        // auto a = build_ingress(const_cast<CombineLatest*>(this), std::index_sequence_for<TypesT...>{});
-    }
+    {}
 
     virtual ~CombineLatest() = default;
 
@@ -193,9 +120,9 @@ class CombineLatest : public WritableAcceptor<std::tuple<TypesT...>>
         // Check if we should push the new value
         if (m_values_set == sizeof...(TypesT))
         {
-            // std::tuple<TypesT...> new_val = surely2(m_state);
+            std::tuple<TypesT...> new_val = surely(m_state);
 
-            // status = this->get_writable_edge()->await_write(std::move(new_val));
+            status = this->get_writable_edge()->await_write(std::move(new_val));
         }
 
         return status;
@@ -209,6 +136,9 @@ class CombineLatest : public WritableAcceptor<std::tuple<TypesT...>>
 
         if (m_completions == sizeof...(TypesT))
         {
+            // Clear the held tuple to remove any dangling values
+            m_state = std::tuple<std::optional<TypesT>...>();
+
             WritableAcceptor<std::tuple<TypesT...>>::release_edge_connection();
         }
     }

--- a/cpp/mrc/include/mrc/node/operators/with_latest_from.hpp
+++ b/cpp/mrc/include/mrc/node/operators/with_latest_from.hpp
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mrc/channel/buffered_channel.hpp"
+#include "mrc/channel/status.hpp"
+#include "mrc/core/utils.hpp"
+#include "mrc/node/sink_properties.hpp"
+#include "mrc/node/source_properties.hpp"
+#include "mrc/utils/tuple_utils.hpp"
+#include "mrc/utils/type_utils.hpp"
+
+#include <boost/fiber/mutex.hpp>
+#include <glog/logging.h>
+
+#include <memory>
+#include <mutex>
+#include <tuple>
+#include <utility>
+
+namespace mrc::node {
+
+template <typename... TypesT>
+class WithLatestFrom : public WritableAcceptor<std::tuple<TypesT...>>
+{
+    template <typename T>
+    using queue_t = BufferedChannel<T>;
+    template <typename T>
+    using wrapped_queue_t = std::unique_ptr<queue_t<T>>;
+    using output_t        = std::tuple<TypesT...>;
+
+    template <std::size_t... Is>
+    static auto build_ingress(WithLatestFrom* self, std::index_sequence<Is...> /*unused*/)
+    {
+        return std::make_tuple(std::make_shared<Upstream<Is>>(*self)...);
+    }
+
+  public:
+    WithLatestFrom() :
+      m_primary_queue(std::make_unique<queue_t<NthTypeOf<0, TypesT...>>>()),
+      m_upstream_holders(build_ingress(const_cast<WithLatestFrom*>(this), std::index_sequence_for<TypesT...>{}))
+    {}
+
+    virtual ~WithLatestFrom() = default;
+
+    template <size_t N>
+    std::shared_ptr<edge::IWritableProvider<NthTypeOf<N, TypesT...>>> get_sink() const
+    {
+        return std::get<N>(m_upstream_holders);
+    }
+
+  protected:
+    template <size_t N>
+    class Upstream : public WritableProvider<NthTypeOf<N, TypesT...>>
+    {
+        using upstream_t = NthTypeOf<N, TypesT...>;
+
+      public:
+        Upstream(WithLatestFrom& parent)
+        {
+            this->init_owned_edge(std::make_shared<InnerEdge>(parent));
+        }
+
+      private:
+        class InnerEdge : public edge::IEdgeWritable<NthTypeOf<N, TypesT...>>
+        {
+          public:
+            InnerEdge(WithLatestFrom& parent) : m_parent(parent) {}
+            ~InnerEdge()
+            {
+                m_parent.edge_complete();
+            }
+
+            virtual channel::Status await_write(upstream_t&& data)
+            {
+                return m_parent.set_upstream_value<N>(std::move(data));
+            }
+
+          private:
+            WithLatestFrom& m_parent;
+        };
+    };
+
+  private:
+    template <size_t N>
+    channel::Status set_upstream_value(NthTypeOf<N, TypesT...> value)
+    {
+        std::unique_lock<decltype(m_mutex)> lock(m_mutex);
+
+        // Get a reference to the current value
+        auto& nth_val = std::get<N>(m_state);
+
+        // Check if we have fully initialized
+        if (m_values_set < sizeof...(TypesT))
+        {
+            if (!nth_val.has_value())
+            {
+                ++m_values_set;
+            }
+
+            // Move the value into the state
+            nth_val = std::move(value);
+
+            // For the primary upstream only, move the value onto a queue
+            if constexpr (N == 0)
+            {
+                // Temporarily unlock to prevent deadlock
+                lock.unlock();
+
+                Unwinder relock([&]() {
+                    lock.lock();
+                });
+
+                // Move it into the queue
+                CHECK_EQ(m_primary_queue->await_write(std::move(nth_val.value())), channel::Status::success);
+            }
+
+            // Check if this put us over the edge
+            if (m_values_set == sizeof...(TypesT))
+            {
+                // Need to complete initialization. First close the primary channel
+                m_primary_queue->close_channel();
+
+                auto& primary_val = std::get<0>(m_state);
+
+                // Loop over the values in the queue, pushing each one
+                while (m_primary_queue->await_read(primary_val.value()) == channel::Status::success)
+                {
+                    std::tuple<TypesT...> new_val = utils::tuple_surely(m_state);
+
+                    CHECK_EQ(this->get_writable_edge()->await_write(std::move(new_val)), channel::Status::success);
+                }
+            }
+        }
+        else
+        {
+            // Move the value into the state
+            nth_val = std::move(value);
+
+            // Only when we are the primary, do we push a new value
+            if constexpr (N == 0)
+            {
+                std::tuple<TypesT...> new_val = utils::tuple_surely(m_state);
+
+                return this->get_writable_edge()->await_write(std::move(new_val));
+            }
+        }
+
+        return channel::Status::success;
+    }
+
+    void edge_complete()
+    {
+        std::unique_lock<decltype(m_mutex)> lock(m_mutex);
+
+        m_completions++;
+
+        if (m_completions == sizeof...(TypesT))
+        {
+            NthTypeOf<0, TypesT...> tmp;
+            bool had_values = false;
+
+            // Try to clear out any values left in the channel
+            while (m_primary_queue->await_read(tmp) == channel::Status::success)
+            {
+                had_values = true;
+            }
+
+            LOG_IF(ERROR, had_values) << "The primary source values were never pushed downstream. Ensure all upstream "
+                                         "sources pushed at least 1 value";
+
+            // Clear the held tuple to remove any dangling values
+            m_state = std::tuple<std::optional<TypesT>...>();
+
+            WritableAcceptor<std::tuple<TypesT...>>::release_edge_connection();
+        }
+    }
+
+    boost::fibers::mutex m_mutex;
+
+    // The number of elements that have been set. Can start emitting when m_values_set == sizeof...(TypesT)
+    size_t m_values_set{0};
+
+    // Counts the number of upstream completions. When m_completions == sizeof...(TypesT), the downstream edges are
+    // released
+    size_t m_completions{0};
+
+    // Holds onto the latest values to eventually push when new ones are emitted
+    std::tuple<std::optional<TypesT>...> m_state;
+
+    // Queue to allow backpressure to upstreams. Only 1 queue for the primary is needed
+    wrapped_queue_t<NthTypeOf<0, TypesT...>> m_primary_queue;
+
+    // Upstream edges
+    std::tuple<std::shared_ptr<WritableProvider<TypesT>>...> m_upstream_holders;
+};
+
+}  // namespace mrc::node

--- a/cpp/mrc/include/mrc/node/operators/zip.hpp
+++ b/cpp/mrc/include/mrc/node/operators/zip.hpp
@@ -1,0 +1,246 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mrc/channel/status.hpp"
+#include "mrc/node/sink_properties.hpp"
+#include "mrc/node/source_properties.hpp"
+#include "mrc/utils/type_utils.hpp"
+
+#include <boost/fiber/buffered_channel.hpp>
+#include <boost/fiber/mutex.hpp>
+#include <boost/fiber/unbuffered_channel.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace mrc::node {
+
+template <std::size_t I = 0, typename FuncT, typename... Tp>
+inline typename std::enable_if<I == sizeof...(Tp), void>::type for_each(std::tuple<Tp...>&, FuncT)  // Unused arguments
+                                                                                                    // are given no
+                                                                                                    // names.
+{}
+
+template <std::size_t I = 0, typename FuncT, typename... Tp>
+    inline typename std::enable_if < I<sizeof...(Tp), void>::type for_each(std::tuple<Tp...>& t, FuncT f)
+{
+    f(std::get<I>(t));
+    for_each<I + 1, FuncT, Tp...>(t, f);
+}
+
+template <typename TupleT, typename FuncT, std::size_t... Is>
+auto tuple_for_each(const TupleT& tuple, FuncT f, std::index_sequence<Is...>)
+{
+    std::tuple<typename std::invoke_result_t<FuncT, std::tuple_element_t<Is, std::decay_t<TupleT>>>...> output;
+
+    return std::tuple<typename std::invoke_result_t<FuncT, std::tuple_element_t<Is, std::decay_t<TupleT>>>...>(
+        (f(std::get<Is>(std::forward<TupleT>(tuple))))...);
+}
+
+template <typename TupleT, typename FuncT, std::size_t... Is>
+auto tuple_for_each(const TupleT& tuple, FuncT f, std::index_sequence<Is...>)
+{
+    return std::tuple<typename std::invoke_result_t<FuncT, std::tuple_element_t<Is, std::decay_t<TupleT>>>...>(
+        (f(std::get<Is>(std::forward<TupleT>(tuple))))...);
+}
+
+template <typename TupleT, typename FuncT>
+auto tuple_for_each(TupleT&& tuple, FuncT&& f)
+{
+    return tuple_for_each(std::forward<TupleT>(tuple),
+                          std::forward<FuncT>(f),
+                          std::make_index_sequence<std::tuple_size<std::decay_t<TupleT>>::value>());
+}
+
+template <typename T, std::size_t... Is>
+bool array_reduce_ge_zero(const std::array<T, sizeof...(Is)>& array, std::index_sequence<Is...>)
+{
+    return ((array[Is] > 0) && ...);
+}
+
+// Retur
+template <typename ArrayT>
+bool array_reduce_ge_zero(const ArrayT& array)
+{
+    return array_reduce_ge_zero(array, std::make_index_sequence<std::tuple_size<std::decay_t<ArrayT>>::value>());
+}
+
+template <typename... TypesT>
+class Zip : public WritableAcceptor<std::tuple<TypesT...>>
+{
+    template <std::size_t... Is>
+    static auto build_ingress(Zip* self, std::index_sequence<Is...> /*unused*/)
+    {
+        return std::make_tuple(std::make_shared<Upstream<Is>>(*self)...);
+    }
+
+    static auto build_vectors()
+    {
+        return std::make_tuple(std::vector<TypesT>()...);
+    }
+
+    static auto build_queues()
+    {
+        return std::make_tuple(std::make_shared<boost::fibers::buffered_channel<TypesT>>(128)...);
+        // return std::make_tuple(boost::fibers::unbuffered_channel<TypesT>()...);
+        // return std::tuple<boost::fibers::unbuffered_channel<int>,
+        // boost::fibers::unbuffered_channel<float>>(boost::fibers::unbuffered_channel<int>(),
+        // boost::fibers::unbuffered_channel<float>());
+        // return std::make_tuple(QueueBuilder<Is>::build()...);
+    }
+
+  public:
+    Zip() :
+      m_queues(build_queues()),
+      m_vectors(build_vectors()),
+      m_upstream_holders(build_ingress(const_cast<Zip*>(this), std::index_sequence_for<TypesT...>{}))
+    {}
+
+    virtual ~Zip() = default;
+
+    template <size_t N>
+    std::shared_ptr<edge::IWritableProvider<NthTypeOf<N, TypesT...>>> get_sink() const
+    {
+        return std::get<N>(m_upstream_holders);
+    }
+
+  protected:
+    template <size_t N>
+    struct QueueBuilder : public WritableProvider<NthTypeOf<N, TypesT...>>
+    {
+        using upstream_t = NthTypeOf<N, TypesT...>;
+
+        static auto build()
+        {
+            return boost::fibers::unbuffered_channel<upstream_t>();
+        }
+    };
+
+    template <size_t N>
+    class Upstream : public WritableProvider<NthTypeOf<N, TypesT...>>
+    {
+        using upstream_t = NthTypeOf<N, TypesT...>;
+
+      public:
+        Upstream(Zip& parent)
+        {
+            this->init_owned_edge(std::make_shared<InnerEdge>(parent));
+        }
+
+      private:
+        class InnerEdge : public edge::IEdgeWritable<NthTypeOf<N, TypesT...>>
+        {
+          public:
+            InnerEdge(Zip& parent) : m_parent(parent) {}
+            ~InnerEdge()
+            {
+                m_parent.edge_complete();
+            }
+
+            virtual channel::Status await_write(upstream_t&& data)
+            {
+                return m_parent.upstream_await_write<N>(std::move(data));
+            }
+
+          private:
+            Zip& m_parent;
+        };
+    };
+
+  private:
+    template <size_t N>
+    channel::Status upstream_await_write(NthTypeOf<N, TypesT...> value)
+    {
+        // Push before locking so we dont deadlock
+        std::get<N>(m_queues)->push(std::move(value));
+
+        std::unique_lock<decltype(m_mutex)> lock(m_mutex);
+
+        // Update the counts array
+        m_queue_counts[N]++;
+
+        // See if we have values in every queue
+        auto all_queues_have_value = std::transform_reduce(m_queue_counts.begin(),
+                                                           m_queue_counts.end(),
+                                                           true,
+                                                           std::logical_and<>(),
+                                                           [](const size_t& v) {
+                                                               return v > 0;
+                                                           });
+
+        channel::Status status = channel::Status::success;
+
+        if (all_queues_have_value)
+        {
+            // For each tuple, pop a value off
+            // std::tuple<TypesT...> new_val = tuple_for_each(m_queues, [](const auto& q){
+
+            // });
+            std::tuple<TypesT...> new_val;
+
+            // Reduce the counts by 1
+            for (auto& c : m_queue_counts)
+            {
+                c--;
+            }
+
+            // Push the new value
+            status = this->get_writable_edge()->await_write(std::move(new_val));
+        }
+
+        return status;
+    }
+
+    void edge_complete()
+    {
+        std::unique_lock<decltype(m_mutex)> lock(m_mutex);
+
+        m_completions++;
+
+        if (m_completions == sizeof...(TypesT))
+        {
+            // Warn on any left over values
+
+            WritableAcceptor<std::tuple<TypesT...>>::release_edge_connection();
+        }
+    }
+
+    boost::fibers::mutex m_mutex;
+    size_t m_values_set{0};
+    size_t m_completions{0};
+    std::array<size_t, sizeof...(TypesT)> m_queue_counts;
+    std::tuple<std::shared_ptr<boost::fibers::buffered_channel<TypesT>>...> m_queues;
+    std::tuple<std::vector<TypesT>...> m_vectors;
+
+    std::tuple<std::shared_ptr<WritableProvider<TypesT>>...> m_upstream_holders;
+};
+
+std::tuple<boost::fibers::unbuffered_channel<int>, boost::fibers::unbuffered_channel<float>> test2(
+    boost::fibers::unbuffered_channel<int>(),
+    boost::fibers::unbuffered_channel<float>());
+
+Zip<int, float> test;
+
+}  // namespace mrc::node

--- a/cpp/mrc/include/mrc/node/sink_channel_owner.hpp
+++ b/cpp/mrc/include/mrc/node/sink_channel_owner.hpp
@@ -38,13 +38,13 @@ class SinkChannelOwner : public virtual SinkProperties<T>
     {
         edge::EdgeChannel<T> edge_channel(std::move(channel));
 
-        this->do_set_channel(edge_channel);
+        this->do_set_channel(std::move(edge_channel));
     }
 
   protected:
     SinkChannelOwner() = default;
 
-    void do_set_channel(edge::EdgeChannel<T>& edge_channel)
+    void do_set_channel(edge::EdgeChannel<T> edge_channel)
     {
         // Create 2 edges, one for reading and writing. On connection, persist the other to allow the node to still use
         // get_readable+edge

--- a/cpp/mrc/include/mrc/node/source_channel_owner.hpp
+++ b/cpp/mrc/include/mrc/node/source_channel_owner.hpp
@@ -40,13 +40,13 @@ class SourceChannelOwner : public virtual SourceProperties<T>
     {
         edge::EdgeChannel<T> edge_channel(std::move(channel));
 
-        this->do_set_channel(edge_channel);
+        this->do_set_channel(std::move(edge_channel));
     }
 
   protected:
     SourceChannelOwner() = default;
 
-    void do_set_channel(edge::EdgeChannel<T>& edge_channel)
+    void do_set_channel(edge::EdgeChannel<T> edge_channel)
     {
         // Create 2 edges, one for reading and writing. On connection, persist the other to allow the node to still use
         // get_writable_edge

--- a/cpp/mrc/include/mrc/utils/tuple_utils.hpp
+++ b/cpp/mrc/include/mrc/utils/tuple_utils.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <tuple>
+
+namespace mrc::utils {
+
+template <typename TupleT, std::size_t... Is>
+auto tuple_surely(TupleT&& tuple, std::index_sequence<Is...> /*unused*/)
+{
+    return std::tuple<typename std::tuple_element_t<Is, std::decay_t<TupleT>>::value_type...>(
+        (std::get<Is>(tuple).value())...);
+}
+
+/**
+ * @brief Converts a std::tuple<std::optional<T1>, std::optional<T2>, ...> to std::tuple<T1, T1, ...>
+ *
+ * @tparam TupleT The type of tuple
+ * @param tuple
+ * @return auto A new Tuple with `std::optional` types removed
+ */
+template <typename TupleT>
+auto tuple_surely(TupleT&& tuple)
+{
+    return tuple_surely(std::forward<TupleT>(tuple),
+                        std::make_index_sequence<std::tuple_size<std::decay_t<TupleT>>::value>());
+}
+
+template <typename TupleT, typename FuncT, std::size_t... Is>
+void tuple_for_each(TupleT&& tuple, FuncT&& f, std::index_sequence<Is...> /*unused*/)
+{
+    (f(std::get<Is>(std::forward<TupleT>(tuple)), Is), ...);
+}
+
+/**
+ * @brief Executes a function for each element of a tuple.
+ *
+ * @tparam TupleT The type of the tuple
+ * @tparam FuncT The type of the lambda
+ * @param tuple Tuple to run the function on
+ * @param f A function which accepts an element of the tuple as the first arg and the index for the second arg.
+ * Recommended to use `auto` or a templated lambda as the first argument
+ */
+template <typename TupleT, typename FuncT>
+void tuple_for_each(TupleT&& tuple, FuncT&& f)
+{
+    tuple_for_each(std::forward<TupleT>(tuple),
+                   std::forward<FuncT>(f),
+                   std::make_index_sequence<std::tuple_size<std::decay_t<TupleT>>::value>());
+}
+}  // namespace mrc::utils

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -19,15 +19,18 @@
 
 #include "mrc/channel/buffered_channel.hpp"  // IWYU pragma: keep
 #include "mrc/channel/forward.hpp"
+#include "mrc/core/utils.hpp"
 #include "mrc/edge/edge_builder.hpp"
 #include "mrc/edge/edge_channel.hpp"
 #include "mrc/edge/edge_readable.hpp"
 #include "mrc/edge/edge_writable.hpp"
+#include "mrc/exceptions/runtime_error.hpp"
 #include "mrc/node/generic_source.hpp"
 #include "mrc/node/operators/broadcast.hpp"
 #include "mrc/node/operators/combine_latest.hpp"
 #include "mrc/node/operators/node_component.hpp"
 #include "mrc/node/operators/router.hpp"
+#include "mrc/node/operators/with_latest_from.hpp"
 #include "mrc/node/operators/zip.hpp"
 #include "mrc/node/rx_node.hpp"
 #include "mrc/node/sink_channel_owner.hpp"
@@ -40,10 +43,14 @@
 #include <gtest/internal/gtest-internal.h>
 #include <rxcpp/rx.hpp>  // for observable_member
 
+#include <deque>
 #include <functional>
+#include <initializer_list>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <ostream>
+#include <queue>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -123,10 +130,16 @@ template <typename T>
 class TestSource : public WritableAcceptor<T>, public ReadableProvider<T>, public SourceChannelOwner<T>
 {
   public:
-    TestSource(std::vector<T> values) : m_values(std::move(values))
+    TestSource(std::vector<T> values) :
+      m_init_values(values),
+      m_values(std::deque<T>(std::make_move_iterator(values.begin()), std::make_move_iterator(values.end())))
     {
         this->set_channel(std::make_unique<mrc::channel::BufferedChannel<T>>());
     }
+
+    TestSource(std::initializer_list<T> values) :
+      TestSource(std::vector<T>(std::make_move_iterator(values.begin()), std::make_move_iterator(values.end())))
+    {}
 
     TestSource(size_t count) : TestSource(gen_values(count)) {}
 
@@ -134,17 +147,39 @@ class TestSource : public WritableAcceptor<T>, public ReadableProvider<T>, publi
 
     void run()
     {
+        // Just push them all
+        this->push(m_values.size());
+    }
+
+    void push_one()
+    {
+        this->push(1);
+    }
+
+    void push(size_t count = 1)
+    {
         auto output = this->get_writable_edge();
 
-        for (auto& i : m_values)
+        for (size_t i = 0; i < count; ++i)
         {
-            if (output->await_write(std::move(i)) != channel::Status::success)
+            if (output->await_write(std::move(m_values.front())) != channel::Status::success)
             {
-                break;
+                this->release_edge_connection();
+                throw exceptions::MrcRuntimeError("Failed to push values. await_write returned non-success status");
             }
+
+            m_values.pop();
         }
 
-        this->release_edge_connection();
+        if (m_values.empty())
+        {
+            this->release_edge_connection();
+        }
+    }
+
+    const std::vector<T>& get_init_values()
+    {
+        return m_init_values;
     }
 
   private:
@@ -160,7 +195,8 @@ class TestSource : public WritableAcceptor<T>, public ReadableProvider<T>, publi
         return values;
     }
 
-    std::vector<T> m_values;
+    std::vector<T> m_init_values;
+    std::queue<T> m_values;
 };
 
 template <typename T>
@@ -174,15 +210,8 @@ class TestNode : public WritableProvider<T>,
   public:
     TestNode()
     {
-        this->set_channel(std::make_unique<mrc::channel::BufferedChannel<T>>());
-    }
-
-    void set_channel(std::unique_ptr<mrc::channel::Channel<T>> channel)
-    {
-        edge::EdgeChannel<T> edge_channel(std::move(channel));
-
-        SinkChannelOwner<T>::do_set_channel(edge_channel);
-        SourceChannelOwner<T>::do_set_channel(edge_channel);
+        SinkChannelOwner<T>::set_channel(std::make_unique<mrc::channel::BufferedChannel<T>>());
+        SourceChannelOwner<T>::set_channel(std::make_unique<mrc::channel::BufferedChannel<T>>());
     }
 
     void run()
@@ -196,7 +225,12 @@ class TestNode : public WritableProvider<T>,
         {
             VLOG(10) << "Node got value: " << t;
 
-            output->await_write(std::move(t));
+            if (output->await_write(std::move(t)) != channel::Status::success)
+            {
+                SinkChannelOwner<T>::release_edge_connection();
+                SourceChannelOwner<T>::release_edge_connection();
+                throw exceptions::MrcRuntimeError("Failed to push values. await_write returned non-success status");
+            }
         }
 
         VLOG(10) << "Node exited run";
@@ -263,17 +297,40 @@ template <typename T>
 class TestSourceComponent : public GenericSourceComponent<T>
 {
   public:
-    TestSourceComponent() = default;
+    TestSourceComponent(std::vector<T> values) :
+      m_init_values(values),
+      m_values(std::deque<T>(std::make_move_iterator(values.begin()), std::make_move_iterator(values.end())))
+    {}
+
+    TestSourceComponent(std::initializer_list<T> values) :
+      TestSourceComponent(
+          std::vector<T>(std::make_move_iterator(values.begin()), std::make_move_iterator(values.end())))
+    {}
+
+    TestSourceComponent(size_t count) : TestSourceComponent(gen_values(count)) {}
+
+    TestSourceComponent() : TestSourceComponent(3) {}
+
+    const std::vector<T>& get_init_values()
+    {
+        return m_init_values;
+    }
 
   protected:
     channel::Status get_data(T& data) override
     {
-        data = m_value++;
+        // Close after all values have been pulled
+        if (m_values.empty())
+        {
+            return channel::Status::closed;
+        }
+
+        data = std::move(m_values.front());
+        m_values.pop();
 
         VLOG(10) << "TestSourceComponent emmitted value: " << data;
 
-        // Close after 3
-        return m_value >= 3 ? channel::Status::closed : channel::Status::success;
+        return channel::Status::success;
     }
 
     void on_complete() override
@@ -282,7 +339,20 @@ class TestSourceComponent : public GenericSourceComponent<T>
     }
 
   private:
-    T m_value{1};
+    static std::vector<T> gen_values(size_t count)
+    {
+        std::vector<T> values;
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            values.emplace_back(i);
+        }
+
+        return values;
+    }
+
+    std::vector<T> m_init_values;
+    std::queue<T> m_values;
 };
 
 template <typename T>
@@ -301,7 +371,7 @@ class TestNodeComponent : public NodeComponent<T, T>
     {
         VLOG(10) << "TestNodeComponent got value: " << t;
 
-        return this->get_writable_edge()->await_write(t + 1);
+        return this->get_writable_edge()->await_write(t);
     }
 
     void do_on_complete() override
@@ -345,9 +415,17 @@ class TestSinkComponent : public WritableProvider<T>
             }));
     }
 
+    const std::vector<T>& get_values()
+    {
+        return m_values;
+    }
+
+  protected:
     channel::Status await_write(int&& t)
     {
         VLOG(10) << "TestSinkComponent got value: " << t;
+
+        m_values.emplace_back(std::move(t));
 
         return channel::Status::success;
     }
@@ -356,6 +434,9 @@ class TestSinkComponent : public WritableProvider<T>
     {
         VLOG(10) << "TestSinkComponent completed";
     }
+
+  private:
+    std::vector<T> m_values;
 };
 
 template <typename T>
@@ -428,6 +509,8 @@ TEST_F(TestEdges, SourceToSink)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToSinkUpcast)
@@ -439,6 +522,15 @@ TEST_F(TestEdges, SourceToSinkUpcast)
 
     source->run();
     sink->run();
+
+    std::vector<float> source_float_vals;
+
+    for (const auto& v : source->get_init_values())
+    {
+        source_float_vals.push_back(v);
+    }
+
+    EXPECT_EQ(source_float_vals, sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToSinkTypeless)
@@ -450,6 +542,8 @@ TEST_F(TestEdges, SourceToSinkTypeless)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToNodeToSink)
@@ -464,6 +558,8 @@ TEST_F(TestEdges, SourceToNodeToSink)
     source->run();
     node->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToNodeToNodeToSink)
@@ -481,6 +577,8 @@ TEST_F(TestEdges, SourceToNodeToNodeToSink)
     node1->run();
     node2->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToSinkMultiFail)
@@ -505,6 +603,8 @@ TEST_F(TestEdges, SourceToSinkComponent)
     mrc::make_edge(*source, *sink);
 
     source->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceComponentToSink)
@@ -515,6 +615,8 @@ TEST_F(TestEdges, SourceComponentToSink)
     mrc::make_edge(*source, *sink);
 
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceComponentToNodeToSink)
@@ -528,6 +630,8 @@ TEST_F(TestEdges, SourceComponentToNodeToSink)
 
     node->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToNodeComponentToSink)
@@ -541,6 +645,8 @@ TEST_F(TestEdges, SourceToNodeComponentToSink)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToNodeToSinkComponent)
@@ -554,6 +660,8 @@ TEST_F(TestEdges, SourceToNodeToSinkComponent)
 
     source->run();
     node->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToNodeComponentToSinkComponent)
@@ -566,6 +674,8 @@ TEST_F(TestEdges, SourceToNodeComponentToSinkComponent)
     mrc::make_edge(*node, *sink);
 
     source->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToRxNodeComponentToSinkComponent)
@@ -586,6 +696,8 @@ TEST_F(TestEdges, SourceToRxNodeComponentToSinkComponent)
     source->run();
 
     EXPECT_TRUE(node->stream_fn_called);
+
+    EXPECT_EQ((std::vector<int>{0, 2, 4}), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceComponentToNodeToSinkComponent)
@@ -598,6 +710,8 @@ TEST_F(TestEdges, SourceComponentToNodeToSinkComponent)
     mrc::make_edge(*node, *sink);
 
     node->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToQueueToSink)
@@ -611,6 +725,8 @@ TEST_F(TestEdges, SourceToQueueToSink)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToQueueToNodeToSink)
@@ -627,6 +743,8 @@ TEST_F(TestEdges, SourceToQueueToNodeToSink)
     source->run();
     node->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToQueueToMultiSink)
@@ -643,6 +761,9 @@ TEST_F(TestEdges, SourceToQueueToMultiSink)
     source->run();
     sink1->run();
     sink2->run();
+
+    EXPECT_EQ(source->get_init_values(), sink1->get_values());
+    EXPECT_EQ(std::vector<int>{}, sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToQueueToDifferentSinks)
@@ -662,6 +783,9 @@ TEST_F(TestEdges, SourceToQueueToDifferentSinks)
     node->run();
     sink1->run();
     sink2->run();
+
+    EXPECT_EQ((std::vector<int>{}), sink1->get_values());
+    EXPECT_EQ(source->get_init_values(), sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToRouterToSinks)
@@ -678,6 +802,9 @@ TEST_F(TestEdges, SourceToRouterToSinks)
     source->run();
     sink1->run();
     sink2->run();
+
+    EXPECT_EQ((std::vector<int>{1}), sink1->get_values());
+    EXPECT_EQ((std::vector<int>{0, 2}), sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToRouterToDifferentSinks)
@@ -693,6 +820,9 @@ TEST_F(TestEdges, SourceToRouterToDifferentSinks)
 
     source->run();
     sink1->run();
+
+    EXPECT_EQ((std::vector<int>{1}), sink1->get_values());
+    EXPECT_EQ((std::vector<int>{0, 2}), sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToBroadcastToSink)
@@ -706,6 +836,8 @@ TEST_F(TestEdges, SourceToBroadcastToSink)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToBroadcastTypelessToSinkSinkFirst)
@@ -719,6 +851,8 @@ TEST_F(TestEdges, SourceToBroadcastTypelessToSinkSinkFirst)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToBroadcastTypelessToSinkSourceFirst)
@@ -732,6 +866,8 @@ TEST_F(TestEdges, SourceToBroadcastTypelessToSinkSourceFirst)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToMultipleBroadcastTypelessToSinkSinkFirst)
@@ -747,6 +883,8 @@ TEST_F(TestEdges, SourceToMultipleBroadcastTypelessToSinkSinkFirst)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, SourceToMultipleBroadcastTypelessToSinkSourceFirst)
@@ -762,6 +900,8 @@ TEST_F(TestEdges, SourceToMultipleBroadcastTypelessToSinkSourceFirst)
 
     source->run();
     sink->run();
+
+    EXPECT_EQ(source->get_init_values(), sink->get_values());
 }
 
 TEST_F(TestEdges, MultiSourceToMultipleBroadcastTypelessToMultiSink)
@@ -783,6 +923,12 @@ TEST_F(TestEdges, MultiSourceToMultipleBroadcastTypelessToMultiSink)
     source2->run();
     sink1->run();
     sink2->run();
+
+    auto expected = source1->get_init_values();
+    expected.insert(expected.end(), source2->get_init_values().begin(), source2->get_init_values().end());
+
+    EXPECT_EQ(expected, sink1->get_values());
+    EXPECT_EQ(expected, sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToBroadcastToMultiSink)
@@ -797,6 +943,11 @@ TEST_F(TestEdges, SourceToBroadcastToMultiSink)
     mrc::make_edge(*broadcast, *sink2);
 
     source->run();
+    sink1->run();
+    sink2->run();
+
+    EXPECT_EQ(source->get_init_values(), sink1->get_values());
+    EXPECT_EQ(source->get_init_values(), sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToBroadcastToDifferentSinks)
@@ -811,6 +962,10 @@ TEST_F(TestEdges, SourceToBroadcastToDifferentSinks)
     mrc::make_edge(*broadcast, *sink2);
 
     source->run();
+    sink1->run();
+
+    EXPECT_EQ(source->get_init_values(), sink1->get_values());
+    EXPECT_EQ(source->get_init_values(), sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceToBroadcastToSinkComponents)
@@ -825,6 +980,9 @@ TEST_F(TestEdges, SourceToBroadcastToSinkComponents)
     mrc::make_edge(*broadcast, *sink2);
 
     source->run();
+
+    EXPECT_EQ(source->get_init_values(), sink1->get_values());
+    EXPECT_EQ(source->get_init_values(), sink2->get_values());
 }
 
 TEST_F(TestEdges, SourceComponentDoubleToSinkFloat)
@@ -835,6 +993,8 @@ TEST_F(TestEdges, SourceComponentDoubleToSinkFloat)
     mrc::make_edge(*source, *sink);
 
     sink->run();
+
+    EXPECT_EQ((std::vector<float>{0, 1, 2}), sink->get_values());
 }
 
 TEST_F(TestEdges, CombineLatest)
@@ -886,6 +1046,149 @@ TEST_F(TestEdges, Zip)
                   std::tuple<int, float>{0, 0},
                   std::tuple<int, float>{1, 1},
                   std::tuple<int, float>{2, 2},
+              }));
+}
+
+TEST_F(TestEdges, ZipEarlyClose)
+{
+    // Have one source emit different counts than the other
+    auto source1 = std::make_shared<node::TestSource<int>>(3);
+    auto source2 = std::make_shared<node::TestSource<float>>(4);
+
+    auto zip = std::make_shared<node::Zip<int, float>>();
+
+    auto sink = std::make_shared<node::TestSink<std::tuple<int, float>>>();
+
+    mrc::make_edge(*source1, *zip->get_sink<0>());
+    mrc::make_edge(*source2, *zip->get_sink<1>());
+    mrc::make_edge(*zip, *sink);
+
+    source1->run();
+
+    // Should throw when pushing last value
+    EXPECT_THROW(source2->run(), exceptions::MrcRuntimeError);
+}
+
+TEST_F(TestEdges, ZipLateClose)
+{
+    // Have one source emit different counts than the other
+    auto source1 = std::make_shared<node::TestSource<int>>(4);
+    auto source2 = std::make_shared<node::TestSource<float>>(3);
+
+    auto zip = std::make_shared<node::Zip<int, float>>();
+
+    auto sink = std::make_shared<node::TestSink<std::tuple<int, float>>>();
+
+    mrc::make_edge(*source1, *zip->get_sink<0>());
+    mrc::make_edge(*source2, *zip->get_sink<1>());
+    mrc::make_edge(*zip, *sink);
+
+    source1->run();
+    source2->run();
+
+    sink->run();
+
+    EXPECT_EQ(sink->get_values(),
+              (std::vector<std::tuple<int, float>>{
+                  std::tuple<int, float>{0, 0},
+                  std::tuple<int, float>{1, 1},
+                  std::tuple<int, float>{2, 2},
+              }));
+}
+
+TEST_F(TestEdges, WithLatestFrom)
+{
+    auto source1 = std::make_shared<node::TestSource<int>>(5);
+    auto source2 = std::make_shared<node::TestSource<float>>(5);
+    auto source3 = std::make_shared<node::TestSource<std::string>>(std::vector<std::string>{"a", "b", "c", "d", "e"});
+
+    auto with_latest = std::make_shared<node::WithLatestFrom<int, float, std::string>>();
+
+    auto sink = std::make_shared<node::TestSink<std::tuple<int, float, std::string>>>();
+
+    mrc::make_edge(*source1, *with_latest->get_sink<0>());
+    mrc::make_edge(*source2, *with_latest->get_sink<1>());
+    mrc::make_edge(*source3, *with_latest->get_sink<2>());
+    mrc::make_edge(*with_latest, *sink);
+
+    // Push 2 from each
+    source2->push(2);
+    source1->push(2);
+    source3->push(2);
+
+    // Push 2 from each
+    source2->push(2);
+    source1->push(2);
+    source3->push(2);
+
+    // Push the rest
+    source3->run();
+    source1->run();
+    source2->run();
+
+    sink->run();
+
+    EXPECT_EQ(sink->get_values(),
+              (std::vector<std::tuple<int, float, std::string>>{
+                  std::tuple<int, float, std::string>{0, 1, "a"},
+                  std::tuple<int, float, std::string>{1, 1, "a"},
+                  std::tuple<int, float, std::string>{2, 3, "b"},
+                  std::tuple<int, float, std::string>{3, 3, "b"},
+                  std::tuple<int, float, std::string>{4, 3, "e"},
+              }));
+}
+
+TEST_F(TestEdges, WithLatestFromUnevenPrimary)
+{
+    auto source1 = std::make_shared<node::TestSource<int>>(5);
+    auto source2 = std::make_shared<node::TestSource<float>>(3);
+
+    auto with_latest = std::make_shared<node::WithLatestFrom<int, float>>();
+
+    auto sink = std::make_shared<node::TestSink<std::tuple<int, float>>>();
+
+    mrc::make_edge(*source1, *with_latest->get_sink<0>());
+    mrc::make_edge(*source2, *with_latest->get_sink<1>());
+    mrc::make_edge(*with_latest, *sink);
+
+    source2->run();
+    source1->run();
+
+    sink->run();
+
+    EXPECT_EQ(sink->get_values(),
+              (std::vector<std::tuple<int, float>>{
+                  std::tuple<int, float>{0, 2},
+                  std::tuple<int, float>{1, 2},
+                  std::tuple<int, float>{2, 2},
+                  std::tuple<int, float>{3, 2},
+                  std::tuple<int, float>{4, 2},
+              }));
+}
+
+TEST_F(TestEdges, WithLatestFromUnevenSecondary)
+{
+    auto source1 = std::make_shared<node::TestSource<int>>(3);
+    auto source2 = std::make_shared<node::TestSource<float>>(5);
+
+    auto with_latest = std::make_shared<node::WithLatestFrom<int, float>>();
+
+    auto sink = std::make_shared<node::TestSink<std::tuple<int, float>>>();
+
+    mrc::make_edge(*source1, *with_latest->get_sink<0>());
+    mrc::make_edge(*source2, *with_latest->get_sink<1>());
+    mrc::make_edge(*with_latest, *sink);
+
+    source1->run();
+    source2->run();
+
+    sink->run();
+
+    EXPECT_EQ(sink->get_values(),
+              (std::vector<std::tuple<int, float>>{
+                  std::tuple<int, float>{0, 0},
+                  std::tuple<int, float>{1, 0},
+                  std::tuple<int, float>{2, 0},
               }));
 }
 

--- a/mrc.code-workspace
+++ b/mrc.code-workspace
@@ -46,6 +46,10 @@
                     {
                         "description": "Skip stdio-common files",
                         "text": "-interpreter-exec console \"skip -gfi **/bits/*.h\""
+                    },
+                    {
+                        "description": "Skip stdio-common files in Conda",
+                        "text": "-interpreter-exec console \"skip -rfu ^std::.*\""
                     }
                     // {
                     //     "description": "Stay on same thread when debugging",
@@ -267,6 +271,10 @@
                 {
                     "description": "Skip stdio-common files",
                     "text": "-interpreter-exec console \"skip -gfi **/bits/*.h\""
+                },
+                {
+                    "description": "Skip stdio-common files everywhere",
+                    "text": "-interpreter-exec console \"skip -rfu ^std::.*\""
                 }
                 // {
                 //     "description": "Stay on same thread when debugging",


### PR DESCRIPTION
## Description
This adds a few new operators for combining multiple streams into one. For example, the code below illustrates using the `Zip` operator

```cpp
auto source1 = std::make_shared<node::TestSource<int>>();
auto source2 = std::make_shared<node::TestSource<float>>();

auto zip = std::make_shared<node::Zip<int, float>>();

auto sink = std::make_shared<node::TestSink<std::tuple<int, float>>>();

mrc::make_edge(*source1, *zip->get_sink<0>());
mrc::make_edge(*source2, *zip->get_sink<1>());
mrc::make_edge(*zip, *sink);

source1->run();
source2->run();

sink->run();

EXPECT_EQ(sink->get_values(),
            (std::vector<std::tuple<int, float>>{
                std::tuple<int, float>{0, 0},
                std::tuple<int, float>{1, 1},
                std::tuple<int, float>{2, 2},
            }));
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
