### PR TITLE
Remove `boost::filesystem`

### DIFF
--- a/cpp/mrc/src/public/modules/plugins.cpp
+++ b/cpp/mrc/src/public/modules/plugins.cpp
@@ -17,13 +17,11 @@
 
 #include "mrc/modules/plugins.hpp"
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/path_traits.hpp>
 #include <dlfcn.h>
 #include <glog/logging.h>
 
 #include <exception>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -31,7 +29,7 @@
 #include <string>
 #include <utility>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace mrc::modules {
 

--- a/cpp/mrc/src/public/modules/plugins.cpp
+++ b/cpp/mrc/src/public/modules/plugins.cpp
@@ -20,6 +20,7 @@
 #include <dlfcn.h>
 #include <glog/logging.h>
 
+#include <chrono>
 #include <exception>
 #include <filesystem>
 #include <memory>

--- a/cpp/mrc/tests/modules/test_module_registry.cpp
+++ b/cpp/mrc/tests/modules/test_module_registry.cpp
@@ -32,7 +32,6 @@
 #include "mrc/segment/object.hpp"
 #include "mrc/version.hpp"
 
-#include <boost/filesystem/path.hpp>
 #include <dlfcn.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
@@ -41,6 +40,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -189,7 +189,7 @@ std::string get_modules_path()
     std::vector<char> path_buffer(sz_path_buffer + 1);
     readlink(link_id.c_str(), path_buffer.data(), sz_path_buffer);
 
-    boost::filesystem::path whereami(path_buffer.data());
+    std::filesystem::path whereami(path_buffer.data());
 
     std::string modules_path = whereami.parent_path().string() + "/modules/";
 


### PR DESCRIPTION
## Description
This PR removes all references to `boost::filesystem` in favor of `std::filesystem`. The std library should be preferred over the boost version

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
