### PR TITLE
Workaround GCC 11.3 compiler bug

### DIFF
--- a/cpp/mrc/include/mrc/coroutines/ring_buffer.hpp
+++ b/cpp/mrc/include/mrc/coroutines/ring_buffer.hpp
@@ -158,23 +158,42 @@ class RingBuffer
             return (!m_stopped ? RingBufferOpStatus::Success : RingBufferOpStatus::Stopped);
         }
 
-        WriteOperation& use_scheduling_policy(SchedulePolicy policy)
+        WriteOperation& use_scheduling_policy(SchedulePolicy policy) &
         {
             m_policy = policy;
             return *this;
         }
 
-        WriteOperation& resume_immediately()
+        WriteOperation use_scheduling_policy(SchedulePolicy policy) &&
+        {
+            m_policy = policy;
+            return std::move(*this);
+        }
+
+        WriteOperation& resume_immediately() &
         {
             m_policy = SchedulePolicy::Immediate;
             return *this;
         }
 
-        WriteOperation& resume_on(ThreadPool* thread_pool)
+        WriteOperation resume_immediately() &&
+        {
+            m_policy = SchedulePolicy::Immediate;
+            return std::move(*this);
+        }
+
+        WriteOperation& resume_on(ThreadPool* thread_pool) &
         {
             m_policy = SchedulePolicy::Reschedule;
             set_resume_on_thread_pool(thread_pool);
             return *this;
+        }
+
+        WriteOperation resume_on(ThreadPool* thread_pool) &&
+        {
+            m_policy = SchedulePolicy::Reschedule;
+            set_resume_on_thread_pool(thread_pool);
+            return std::move(*this);
         }
 
       private:

--- a/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
+++ b/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
@@ -216,15 +216,24 @@ TEST_F(TestCoroRingBuffer, MultiProducerMultiConsumer)
         {
             switch (i % 3)
             {
-            case 0:
+            case 0: {
                 co_await rb.write(i);
                 break;
-            case 1:
-                co_await rb.write(i).resume_immediately();
+            }
+            case 1: {
+                // Must save this to a temporary to workaround compiler bug in GCC==11.3 (working in 11.2/11.4). See:
+                // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103871#c10
+                auto& task = rb.write(i).resume_immediately();
+                co_await task;
                 break;
-            case 2:
-                co_await rb.write(i).resume_on(&tp);
+            }
+            case 2: {
+                // Must save this to a temporary to workaround compiler bug in GCC==11.3 (working in 11.2/11.4). See:
+                // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103871#c10
+                auto& task = rb.write(i).resume_on(&tp);
+                co_await task;
                 break;
+            }
             }
         }
 

--- a/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
+++ b/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
@@ -216,24 +216,15 @@ TEST_F(TestCoroRingBuffer, MultiProducerMultiConsumer)
         {
             switch (i % 3)
             {
-            case 0: {
+            case 0:
                 co_await rb.write(i);
                 break;
-            }
-            case 1: {
-                // Must save this to a temporary to workaround compiler bug in GCC==11.3 (working in 11.2/11.4). See:
-                // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103871#c10
-                auto& task = rb.write(i).resume_immediately();
-                co_await task;
+            case 1:
+                co_await rb.write(i).resume_immediately();
                 break;
-            }
-            case 2: {
-                // Must save this to a temporary to workaround compiler bug in GCC==11.3 (working in 11.2/11.4). See:
-                // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103871#c10
-                auto& task = rb.write(i).resume_on(&tp);
-                co_await task;
+            case 2:
+                co_await rb.write(i).resume_on(&tp);
                 break;
-            }
             }
         }
 


### PR DESCRIPTION
## Description
Compiling on GCC 11.3 breaks due to this compiler bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103871. Using the workaround in [this](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103871#c10) comment seems to fix the issue.

Tested on 11.3 locally. Changes should be benign. No way to test this in CI without adding GCC 11.3 to the build matrix.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
