### PR TITLE
Fix the conda build with RMM 23.02

### DIFF
--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -53,6 +53,9 @@ export CMAKE_C_COMPILER_LAUNCHER="ccache"
 export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
 export CMAKE_CUDA_COMPILER_LAUNCHER="ccache"
 
+# Avoid confirmation messages during the conda build
+export CONDA_ALWAYS_YES=true
+
 # Holds the arguments in an array to allow for complex json objects
 CONDA_ARGS_ARRAY=()
 

--- a/cpp/mrc/include/mrc/memory/resources/arena_resource.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/arena_resource.hpp
@@ -23,7 +23,6 @@
 #include <cuda_runtime_api.h>
 #include <glog/logging.h>
 #include <rmm/detail/error.hpp>
-#include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 
 #include <cstddef>
@@ -242,7 +241,7 @@ class arena_resource final : public adaptor<Upstream>
      * @return arena& The arena associated with the given stream.
     arena& get_stream_arena(cuda_stream_view stream)
     {
-        RMM_LOGGING_ASSERT(!use_per_thread_arena(stream));
+        DCHECK(!use_per_thread_arena(stream));
         {
             read_lock lock(mtx_);
             auto const iter = stream_arenas_.find(stream.value());

--- a/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
+++ b/cpp/mrc/include/mrc/memory/resources/detail/arena.hpp
@@ -18,10 +18,10 @@
 #pragma once
 
 #include <cuda_runtime_api.h>
+#include <glog/logging.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
-#include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 
 #include <algorithm>
@@ -122,7 +122,7 @@ class block
      */
     [[nodiscard]] std::pair<block, block> split(std::size_t size) const
     {
-        RMM_LOGGING_ASSERT(size_ >= size);
+        DCHECK(size_ >= size);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         if (size_ > size)
         {
@@ -141,7 +141,7 @@ class block
      */
     [[nodiscard]] block merge(block const& blk) const
     {
-        RMM_LOGGING_ASSERT(is_contiguous_before(blk));
+        DCHECK(is_contiguous_before(blk));
         return {pointer_, size_ + blk.size_};
     }
 


### PR DESCRIPTION
## Description
The conda build failed on the RMM 23.02 variant as shown [here](https://github.com/nv-morpheus/MRC/actions/runs/5481558555/jobs/9986229915) due to the change with moving `RMM_LOGGING_ASSERT` between versions 23.02 and 23.04.

This fix removes uses of `RMM_LOGGING_ASSERT` replacing it with the equivalent `DCHECK` which is used throughout the rest of the repo.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
