### PR TITLE
Adding option to configure running the conda-build CI step with labels

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -19,10 +19,16 @@ run-name: CI Pipeline
 on:
   workflow_call:
     inputs:
+      pr_info:
+        required: true
+        type: string
       run_check:
         required: true
         type: boolean
       run_package_conda:
+        required: true
+        type: boolean
+      upload_conda_package:
         required: true
         type: boolean
       container:
@@ -38,6 +44,11 @@ on:
         required: true
       NGC_API_KEY:
         required: true
+
+# We only support ubuntu, so bash is the default
+defaults:
+  run:
+    shell: bash
 
 env:
   CHANGE_TARGET: "${{ github.base_ref }}"
@@ -313,4 +324,5 @@ jobs:
         shell: bash
         env:
           CONDA_TOKEN: "${{ secrets.CONDA_TOKEN }}"
-        run: ./mrc/ci/scripts/github/conda.sh
+          SCRIPT_ARGS: "${{ inputs.upload_conda_package && 'upload' || '' }}"
+        run: ./mrc/ci/scripts/github/conda.sh $SCRIPT_ARGS

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -19,9 +19,6 @@ run-name: CI Pipeline
 on:
   workflow_call:
     inputs:
-      pr_info:
-        required: true
-        type: string
       run_check:
         required: true
         type: boolean
@@ -35,6 +32,9 @@ on:
         required: true
         type: string
       test_container:
+        required: true
+        type: string
+      pr_info:
         required: true
         type: string
     secrets:
@@ -74,41 +74,6 @@ permissions:
   statuses: none
 
 jobs:
-  debug_package:
-    name: Debug Package
-    if: ${{ inputs.run_package_conda }}
-    runs-on: linux-amd64-cpu16
-    timeout-minutes: 60
-    container:
-      credentials:
-        username: '$oauthtoken'
-        password: ${{ secrets.NGC_API_KEY }}
-      image: ${{ inputs.container }}
-    strategy:
-      fail-fast: true
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: false
-          path: 'mrc'
-          fetch-depth: 0
-
-      - name: Get AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
-          role-duration-seconds: 43200 # 12h
-
-      - name: conda
-        shell: bash
-        env:
-          CONDA_TOKEN: "${{ secrets.CONDA_TOKEN }}"
-          SCRIPT_ARGS: ${{ inputs.upload_conda_package && 'test' || 'fail' }}
-        run: ./mrc/ci/scripts/github/conda.sh $SCRIPT_ARGS
-
   check:
     if: ${{ inputs.run_check }}
     name: Check
@@ -359,5 +324,5 @@ jobs:
         shell: bash
         env:
           CONDA_TOKEN: "${{ secrets.CONDA_TOKEN }}"
-          SCRIPT_ARGS: "${{ inputs.upload_conda_package && 'test' || '' }}"
+          SCRIPT_ARGS: "${{ inputs.upload_conda_package && 'upload' || '' }}"
         run: ./mrc/ci/scripts/github/conda.sh $SCRIPT_ARGS

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -74,6 +74,41 @@ permissions:
   statuses: none
 
 jobs:
+  debug_package:
+    name: Debug Package
+    if: ${{ inputs.run_package_conda }}
+    runs-on: linux-amd64-cpu16
+    timeout-minutes: 60
+    container:
+      credentials:
+        username: '$oauthtoken'
+        password: ${{ secrets.NGC_API_KEY }}
+      image: ${{ inputs.container }}
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: false
+          path: 'mrc'
+          fetch-depth: 0
+
+      - name: Get AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 43200 # 12h
+
+      - name: conda
+        shell: bash
+        env:
+          CONDA_TOKEN: "${{ secrets.CONDA_TOKEN }}"
+          SCRIPT_ARGS: ${{ inputs.upload_conda_package && 'test' || 'fail' }}
+        run: ./mrc/ci/scripts/github/conda.sh $SCRIPT_ARGS
+
   check:
     if: ${{ inputs.run_check }}
     name: Check
@@ -324,5 +359,5 @@ jobs:
         shell: bash
         env:
           CONDA_TOKEN: "${{ secrets.CONDA_TOKEN }}"
-          SCRIPT_ARGS: "${{ inputs.upload_conda_package && 'upload' || '' }}"
+          SCRIPT_ARGS: "${{ inputs.upload_conda_package && 'test' || '' }}"
         run: ./mrc/ci/scripts/github/conda.sh $SCRIPT_ARGS

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
     with:
       pr_info: ${{ needs.prepare.outputs.pr_info }}
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ needs.prepare.outputs.has_conda_build_label }}
+      run_package_conda: true
       upload_conda_package: ${{ !startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230412
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230412

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,11 +43,27 @@ permissions:
   statuses: none
 
 jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+      container:
+        image: rapidsai/ci:latest
+    steps:
+      - name: Get PR Info
+        id: get-pr-info
+        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.08
+    outputs:
+      pr_info: ${{ steps.get-pr-info.outputs.pr-info }}
+      has_conda_build_label: ${{ contains(fromJSON(steps.get-pr-info.outputs.pr-info).labels.*.name, 'conda-build') }}
   ci_pipe:
+    name: CI Pipeline
+    needs: [prepare]
     uses: ./.github/workflows/ci_pipe.yml
     with:
+      pr_info: ${{ needs.prepare.outputs.pr_info }}
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') }}
+      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') || needs.prepare.outputs.has_conda_build_label }}
+      upload_conda_package: ${{ !startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230412
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230412
     secrets:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -54,18 +54,20 @@ jobs:
         uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.08
     outputs:
       pr_info: ${{ steps.get-pr-info.outputs.pr-info }}
+      is_pr: ${{ startsWith(github.ref_name, 'pull-request/') }}
+      is_main_branch: ${{ startsWith(github.ref_name, 'branch-') }}
       has_conda_build_label: ${{ contains(fromJSON(steps.get-pr-info.outputs.pr-info).labels.*.name, 'conda-build') }}
   ci_pipe:
     name: CI Pipeline
     needs: [prepare]
     uses: ./.github/workflows/ci_pipe.yml
     with:
-      pr_info: ${{ needs.prepare.outputs.pr_info }}
-      run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ contains(fromJSON(needs.prepare.outputs.pr_info).labels.*.name, 'conda-build') }}
-      upload_conda_package: ${{ !startsWith(github.ref_name, 'pull-request/') }}
+      run_check: ${{ fromJSON(needs.prepare.outputs.is_pr) }}
+      run_package_conda: ${{ fromJSON(needs.prepare.outputs.is_main_branch) || fromJSON(needs.prepare.outputs.has_conda_build_label) }}
+      upload_conda_package: ${{ fromJSON(needs.prepare.outputs.is_main_branch) }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230412
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230412
+      pr_info: ${{ needs.prepare.outputs.pr_info }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
     with:
       pr_info: ${{ needs.prepare.outputs.pr_info }}
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: true
+      run_package_conda: ${{ contains(fromJSON(needs.prepare.outputs.pr_info).labels.*.name, 'conda-build') }}
       upload_conda_package: ${{ !startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230412
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230412

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
     with:
       pr_info: ${{ needs.prepare.outputs.pr_info }}
       run_check: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      run_package_conda: ${{ !startsWith(github.ref_name, 'pull-request/') || needs.prepare.outputs.has_conda_build_label }}
+      run_package_conda: ${{ needs.prepare.outputs.has_conda_build_label }}
       upload_conda_package: ${{ !startsWith(github.ref_name, 'pull-request/') }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230412
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230412

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,8 +46,8 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
-      container:
-        image: rapidsai/ci:latest
+    container:
+      image: rapidsai/ci:latest
     steps:
       - name: Get PR Info
         id: get-pr-info

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -39,4 +39,4 @@ conda info
 rapids-logger "Building Conda Package"
 
 # Run the conda build and upload
-${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh upload
+${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh "$@"

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -38,7 +38,5 @@ conda info
 
 rapids-logger "Building Conda Package"
 
-echo "Command: ${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh $@"
-
 # Run the conda build and upload
 ${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh "$@"

--- a/ci/scripts/github/conda.sh
+++ b/ci/scripts/github/conda.sh
@@ -38,5 +38,7 @@ conda info
 
 rapids-logger "Building Conda Package"
 
+echo "Command: ${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh $@"
+
 # Run the conda build and upload
 ${MRC_ROOT}/ci/conda/recipes/run_conda_build.sh "$@"


### PR DESCRIPTION
## Description
This PR is testing the ability to enable/disable CI steps via labels on a PR. Uses the new action `rapidsai/shared-action-workflows/get-pr-info`

New label is `conda-build`.