### PR TITLE
Fixing actions running on non-PR branches

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -30,7 +30,7 @@ on:
       conda_upload_label:
         description: 'The label to use when uploading the conda package. Leave empty to disable uploading'
         required: true
-        type: boolean
+        type: string
       container:
         description: 'The container to use for all stages except the test stage'
         required: true

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -20,21 +20,27 @@ on:
   workflow_call:
     inputs:
       run_check:
+        description: 'Runs the check stage to verify code integrity'
         required: true
         type: boolean
-      run_package_conda:
+      conda_run_build:
+        description: 'Runs the conda-build stage to ensure the conda package builds successfully'
         required: true
         type: boolean
-      upload_conda_package:
+      conda_upload_label:
+        description: 'The label to use when uploading the conda package. Leave empty to disable uploading'
         required: true
         type: boolean
       container:
+        description: 'The container to use for all stages except the test stage'
         required: true
         type: string
       test_container:
+        description: 'The container to use for the test stage'
         required: true
         type: string
       pr_info:
+        description: 'The JSON string containing the PR information'
         required: true
         type: string
     secrets:
@@ -293,7 +299,7 @@ jobs:
 
   package:
     name: Package
-    if: ${{ inputs.run_package_conda }}
+    if: ${{ inputs.conda_run_build }}
     needs: [benchmark, documentation, test]
     runs-on: linux-amd64-cpu16
     timeout-minutes: 60
@@ -324,5 +330,6 @@ jobs:
         shell: bash
         env:
           CONDA_TOKEN: "${{ secrets.CONDA_TOKEN }}"
-          SCRIPT_ARGS: "${{ inputs.upload_conda_package && 'upload' || '' }}"
+          SCRIPT_ARGS: "${{ inputs.conda_upload_label != '' && 'upload' || '' }}"
+          CONDA_PKG_LABEL: "${{ inputs.conda_upload_label }}"
         run: ./mrc/ci/scripts/github/conda.sh $SCRIPT_ARGS

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,11 +52,12 @@ jobs:
       - name: Get PR Info
         id: get-pr-info
         uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.08
+        if: ${{ startsWith(github.ref_name, 'pull-request/') }}
     outputs:
-      pr_info: ${{ steps.get-pr-info.outputs.pr-info }}
       is_pr: ${{ startsWith(github.ref_name, 'pull-request/') }}
       is_main_branch: ${{ startsWith(github.ref_name, 'branch-') }}
-      has_conda_build_label: ${{ contains(fromJSON(steps.get-pr-info.outputs.pr-info).labels.*.name, 'conda-build') }}
+      has_conda_build_label: ${{ steps.get-pr-info.outcome == 'success' && contains(fromJSON(steps.get-pr-info.outputs.pr-info).labels.*.name, 'conda-build') || false }}
+      pr_info: ${{ steps.get-pr-info.outcome == 'success' && steps.get-pr-info.outputs.pr-info || '' }}
   ci_pipe:
     name: CI Pipeline
     needs: [prepare]
@@ -67,7 +68,6 @@ jobs:
       upload_conda_package: ${{ fromJSON(needs.prepare.outputs.is_main_branch) }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230711
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230711
-      pr_info: ${{ needs.prepare.outputs.pr_info }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -68,6 +68,7 @@ jobs:
       upload_conda_package: ${{ fromJSON(needs.prepare.outputs.is_main_branch) }}
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230711
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230711
+      pr_info: ${{ needs.prepare.outputs.pr_info }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Get PR Info
         id: get-pr-info
         uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.08
-        if: ${{ startsWith(github.ref_name, 'pull-request/') && false }}
+        if: ${{ startsWith(github.ref_name, 'pull-request/') }}
     outputs:
       is_pr: ${{ startsWith(github.ref_name, 'pull-request/') }}
       is_main_branch: ${{ startsWith(github.ref_name, 'branch-') }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,7 +55,8 @@ jobs:
         if: ${{ startsWith(github.ref_name, 'pull-request/') }}
     outputs:
       is_pr: ${{ startsWith(github.ref_name, 'pull-request/') }}
-      is_main_branch: ${{ startsWith(github.ref_name, 'branch-') }}
+      is_main_branch: ${{ github.ref_name == 'main' }}
+      is_dev_branch: ${{ startsWith(github.ref_name, 'branch-') }}
       has_conda_build_label: ${{ steps.get-pr-info.outcome == 'success' && contains(fromJSON(steps.get-pr-info.outputs.pr-info).labels.*.name, 'conda-build') || false }}
       pr_info: ${{ steps.get-pr-info.outcome == 'success' && steps.get-pr-info.outputs.pr-info || '' }}
   ci_pipe:
@@ -63,11 +64,17 @@ jobs:
     needs: [prepare]
     uses: ./.github/workflows/ci_pipe.yml
     with:
+      # Run checks for any PR branch
       run_check: ${{ fromJSON(needs.prepare.outputs.is_pr) }}
-      run_package_conda: ${{ fromJSON(needs.prepare.outputs.is_main_branch) || fromJSON(needs.prepare.outputs.has_conda_build_label) }}
-      upload_conda_package: ${{ fromJSON(needs.prepare.outputs.is_main_branch) }}
+      # Run conda-build for main/dev branches and PRs with the conda-build label
+      conda_run_build: ${{ !fromJSON(needs.prepare.outputs.is_pr) || fromJSON(needs.prepare.outputs.has_conda_build_label) }}
+      # Update conda package only for non PR branches. Use 'main' for main branch and 'dev' for all other branches
+      conda_upload_label: ${{ !fromJSON(needs.prepare.outputs.is_pr) && (fromJSON(needs.prepare.outputs.is_main_branch) && 'main' || 'dev') || '' }}
+      # Build container
       container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-build-230711
+      # Test container
       test_container: nvcr.io/ea-nvidia-morpheus/morpheus:mrc-ci-test-230711
+      # Info about the PR. Empty for non PR branches. Useful for extracting PR number, title, etc.
       pr_info: ${{ needs.prepare.outputs.pr_info }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Get PR Info
         id: get-pr-info
         uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.08
-        if: ${{ startsWith(github.ref_name, 'pull-request/') }}
+        if: ${{ startsWith(github.ref_name, 'pull-request/') && false }}
     outputs:
       is_pr: ${{ startsWith(github.ref_name, 'pull-request/') }}
       is_main_branch: ${{ startsWith(github.ref_name, 'branch-') }}


### PR DESCRIPTION
## Description
Actions running after a PR is merged are broken due to the Prepare step assuming there is a PR. This fixes the prepare step to work with and without a PR
