### PR TITLE
Updates for MRC/Morpheus to build in the same RAPIDS devcontainer environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,10 @@ option(MRC_BUILD_DOCS "Enable building of API documentation" OFF)
 option(MRC_BUILD_LIBRARY "Whether the entire MRC library should be built.
   If set to OFF, only the pieces needed for a target will be built. Set to ON if installing the library" ON)
 option(MRC_BUILD_PYTHON "Enable building the python bindings for MRC" ON)
-option(MRC_PYTHON_INPLACE_BUILD "Whether or not to copy built python modules back to the source tree for debug purposes." OFF)
 option(MRC_BUILD_TESTS "Whether or not to build MRC tests" ON)
 option(MRC_ENABLE_CODECOV "Enable gcov code coverage" OFF)
 option(MRC_ENABLE_DEBUG_INFO "Enable printing debug information" OFF)
+option(MRC_PYTHON_INPLACE_BUILD "Whether or not to copy built python modules back to the source tree for debug purposes." OFF)
 option(MRC_USE_CCACHE "Enable caching compilation results with ccache" OFF)
 option(MRC_USE_CLANG_TIDY "Enable running clang-tidy as part of the build process" OFF)
 option(MRC_USE_CONDA "Enables finding dependencies via conda. All dependencies must be installed first in the conda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(MRC_BUILD_DOCS "Enable building of API documentation" OFF)
 option(MRC_BUILD_LIBRARY "Whether the entire MRC library should be built.
   If set to OFF, only the pieces needed for a target will be built. Set to ON if installing the library" ON)
 option(MRC_BUILD_PYTHON "Enable building the python bindings for MRC" ON)
+option(MRC_PYTHON_INPLACE_BUILD "Whether or not to copy built python modules back to the source tree for debug purposes." OFF)
 option(MRC_BUILD_TESTS "Whether or not to build MRC tests" ON)
 option(MRC_ENABLE_CODECOV "Enable gcov code coverage" OFF)
 option(MRC_ENABLE_DEBUG_INFO "Enable printing debug information" OFF)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -48,7 +48,7 @@ dependencies:
           - python=3.10
   cudatoolkit:
     specific:
-      - output_types: conda
+      - output_types: [conda]
         matrices:
           - matrix:
               cuda: "11.8"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,113 @@
+# Dependency list for https://github.com/rapidsai/dependency-file-generator
+files:
+  all:
+    output: conda
+    matrix:
+      cuda: ["11.8"]
+      arch: [x86_64]
+    includes:
+      - empty
+      - build_cpp
+      # - build_python
+      - cudatoolkit
+
+channels:
+  - rapidsai
+  - nvidia/label/cuda-11.8.0
+  - nvidia
+  - rapidsai-nightly
+  - conda-forge
+
+dependencies:
+
+  empty:
+    common:
+      - output_types: [conda]
+        packages:
+          - cxx-compiler
+
+  build_cpp:
+    common:
+      - output_types: [conda]
+        packages:
+          - boost-cpp=1.82
+          - ccache
+          - cmake=3.24
+          - cuda-nvcc
+          - cxx-compiler
+          - glog=0.6
+          - gxx=11.2
+          - libgrpc=1.54.0
+          - libhwloc=2.9.2
+          - librmm=23.06
+          - ninja=1.10
+          - ucx=1.14
+          - nlohmann_json=3.9
+          - gtest=1.13
+          - scikit-build>=0.17
+          - pybind11-stubgen=0.10
+          - python=3.10
+  # build_python:
+  #   common:
+  #     - output_types: [conda, requirements, pyproject]
+  #       packages:
+  #         - cython>=3.0.0
+  #         - scikit-build>=0.13.1
+  #         - setuptools
+  #     - output_types: conda
+  #       packages: &build_python_packages_conda
+  #         - &cudf_conda cudf==23.10.*
+  #         - &rmm_conda rmm==23.10.*
+  #     - output_types: requirements
+  #       packages:
+  #         # pip recognizes the index as a global option for the requirements.txt file
+  #         # This index is needed for cudf and rmm.
+  #         - --extra-index-url=https://pypi.nvidia.com
+  #   specific:
+  #     - output_types: conda
+  #       matrices:
+  #         - matrix:
+  #             arch: x86_64
+  #           packages:
+  #             - *gcc_amd64
+  #             - *sysroot_amd64
+  #         - matrix:
+  #             arch: aarch64
+  #           packages:
+  #             - *gcc_aarch64
+  #             - *sysroot_aarch64
+  #     - output_types: [requirements, pyproject]
+  #       matrices:
+  #         - matrix: {cuda: "12.0"}
+  #           packages:
+  #             - cudf-cu12==23.10.*
+  #             - rmm-cu12==23.10.*
+  #         - matrix: {cuda: "11.8"}
+  #           packages: &build_python_packages_cu11
+  #             - &cudf_cu11 cudf-cu11==23.10.*
+  #             - &rmm_cu11 rmm-cu11==23.10.*
+  #         - {matrix: {cuda: "11.5"}, packages: *build_python_packages_cu11}
+  #         - {matrix: {cuda: "11.4"}, packages: *build_python_packages_cu11}
+  #         - {matrix: {cuda: "11.2"}, packages: *build_python_packages_cu11}
+  #         - {matrix: null, packages: [*cudf_conda, *rmm_conda] }
+  cudatoolkit:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "12.2"
+            packages:
+              - cuda-cudart-dev
+              - cuda-cudart-static
+              - cuda-nvrtc-dev
+              - cuda-version=12.2
+              - cuda-nvml-dev
+              - cuda-tools
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cuda-cudart-dev=11.8
+              - cuda-nvrtc-dev=11.8
+              - cuda-version=11.8
+              - cuda-nvml-dev=11.8
+              - cuda-tools=11.8

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,7 +8,6 @@ files:
     includes:
       - empty
       - build_cpp
-      # - build_python
       - cudatoolkit
 
 channels:
@@ -47,62 +46,10 @@ dependencies:
           - scikit-build>=0.17
           - pybind11-stubgen=0.10
           - python=3.10
-  # build_python:
-  #   common:
-  #     - output_types: [conda, requirements, pyproject]
-  #       packages:
-  #         - cython>=3.0.0
-  #         - scikit-build>=0.13.1
-  #         - setuptools
-  #     - output_types: conda
-  #       packages: &build_python_packages_conda
-  #         - &cudf_conda cudf==23.10.*
-  #         - &rmm_conda rmm==23.10.*
-  #     - output_types: requirements
-  #       packages:
-  #         # pip recognizes the index as a global option for the requirements.txt file
-  #         # This index is needed for cudf and rmm.
-  #         - --extra-index-url=https://pypi.nvidia.com
-  #   specific:
-  #     - output_types: conda
-  #       matrices:
-  #         - matrix:
-  #             arch: x86_64
-  #           packages:
-  #             - *gcc_amd64
-  #             - *sysroot_amd64
-  #         - matrix:
-  #             arch: aarch64
-  #           packages:
-  #             - *gcc_aarch64
-  #             - *sysroot_aarch64
-  #     - output_types: [requirements, pyproject]
-  #       matrices:
-  #         - matrix: {cuda: "12.0"}
-  #           packages:
-  #             - cudf-cu12==23.10.*
-  #             - rmm-cu12==23.10.*
-  #         - matrix: {cuda: "11.8"}
-  #           packages: &build_python_packages_cu11
-  #             - &cudf_cu11 cudf-cu11==23.10.*
-  #             - &rmm_cu11 rmm-cu11==23.10.*
-  #         - {matrix: {cuda: "11.5"}, packages: *build_python_packages_cu11}
-  #         - {matrix: {cuda: "11.4"}, packages: *build_python_packages_cu11}
-  #         - {matrix: {cuda: "11.2"}, packages: *build_python_packages_cu11}
-  #         - {matrix: null, packages: [*cudf_conda, *rmm_conda] }
   cudatoolkit:
     specific:
       - output_types: conda
         matrices:
-          - matrix:
-              cuda: "12.2"
-            packages:
-              - cuda-cudart-dev
-              - cuda-cudart-static
-              - cuda-nvrtc-dev
-              - cuda-version=12.2
-              - cuda-nvml-dev
-              - cuda-tools
           - matrix:
               cuda: "11.8"
             packages:

--- a/python/mrc/_pymrc/CMakeLists.txt
+++ b/python/mrc/_pymrc/CMakeLists.txt
@@ -49,8 +49,9 @@ target_link_libraries(pymrc
   PUBLIC
     ${PROJECT_NAME}::libmrc
     ${Python_LIBRARIES}
-    prometheus-cpp::core
     pybind11::pybind11
+  PRIVATE
+    prometheus-cpp::core
 )
 
 target_include_directories(pymrc


### PR DESCRIPTION
Adds a new `dependencies.yaml` which is used in RAPIDS devcontainer utils to generate conda env yamls, `project.toml`'s, and `setup.py`s on-the-fly using https://github.com/rapidsai/dependency-file-generator. Eventually we can generate/verify our existing environment files this way, but for now this gets us up and running in a RAPIDS devcontainer.

Also changes `prometheus-cpp::core` to a `PRIVATE`ly linked library, as it's not longer necessary to be `PUBLIC`, and otherwise breaks a combined MRC/Morpheus build.

Also adds a `MRC_PYTHON_INPLACE_BUILD` cmake option, which enables pybind11 modules to be copied back to the source tree.

MRC/Morpheus unified build environment is a WIP, but available here: https://github.com/cwharris/cyber-dev.

Contributes to https://github.com/nv-morpheus/Morpheus/issues/704

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
