### PR TITLE
Testing SIGSEGV in TestRPC.StreamingPingPong

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!-- omit in toc -->
 # Morpheus Runtime Core (MRC)
+# Minimal change to trigger CI - DO NOT MERGE
 
 The **Morpheus Runtime Core** (MRC) library is a **reactive, network-aware, flexible, and performance-oriented streaming data library** that standardizes building modular and reusable pipelines with both C++ and Python. Designed to efficiently handle non-deterministic volumes and highly variable data streams, MRC is the backbone for NVIDIA's [Morpheus](https://github.com/nv-morpheus/Morpheus) cyber security library. It's goal is to serve as a common high-performance streaming data layer in which all personas of developers, ranging from Data Scientists to DevOps and Performance Engineers, find value.
 

--- a/cpp/mrc/src/internal/control_plane/client.cpp
+++ b/cpp/mrc/src/internal/control_plane/client.cpp
@@ -164,7 +164,7 @@ void Client::do_handle_event(event_t&& event)
         auto* promise = reinterpret_cast<Promise<protos::Event>*>(event.msg.tag());
         if (promise != nullptr)
         {
-            promise->set_value(std::move(event.msg));
+            promise->set_value(event.msg);
         }
     }
     break;

--- a/cpp/mrc/src/tests/test_control_plane.cpp
+++ b/cpp/mrc/src/tests/test_control_plane.cpp
@@ -66,7 +66,8 @@ static auto make_runtime(std::function<void(Options& options)> options_lambda = 
 {
     auto resources = std::make_unique<resources::Manager>(
         system::SystemProvider(tests::make_system([&](Options& options) {
-            options.topology().user_cpuset("0-3");
+            // options.topology().user_cpuset("0-3");
+            options.topology().user_cpuset("0");
             options.topology().restrict_gpus(true);
             options.placement().resources_strategy(PlacementResources::Dedicated);
             options.placement().cpu_strategy(PlacementStrategy::PerMachine);


### PR DESCRIPTION
## Description
Occurs with clang build, I can't repro locally, even locally inside the CI container.
```
[ RUN      ] TestRPC.StreamingPingPong
*** Aborted at 1694016732 (unix time) try "date -d @1694016732" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGSEGV (@0x0) received by PID 4166 (TID 0x7f84edca8000) from PID 0; stack trace: ***
    @     0x7f84fc542197 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f84fc8ce420 (unknown)
    @     0x7f84fc4f4f2e boost::fibers::wait_queue::notify_all()
    @     0x7f84fc4f2ee3 boost::fibers::condition_variable_any::notify_all()
    @     0x7f84fcbe6202 boost::fibers::promise<>::set_value()
    @     0x7f84fcbe50de _ZNK5rxcpp6detail17specific_observerIN3mrc3rpc13ProgressEventENS_8observerIS4_NS0_22stateless_observer_tagEZNS2_4node11GenericSinkIS4_NS2_8runnable7ContextEEC1EvEUlS4_E_NS0_12OnErrorEmptyEvEEvE7on_nextEOS4_
    @     0x7f84fcbe5b2a _ZNK5rxcpp6detail17specific_observerIN3mrc3rpc13ProgressEventENS_8observerIS4_NS0_22stateless_observer_tagEZNS2_4node6RxSinkIS4_NS2_8runnable7ContextEE12do_subscribeERNS_22composite_subscriptionEEUlS4_E_ZNSB_12do_subscribeESD_EUlNSt15__exception_ptr13exception_ptrEE_ZNSB_12do_subscribeESD_EUlvE_EEvE7on_nextEOS4_
    @     0x7f84fcbd7d3a rxcpp::subscriber<>::nextdetacher::operator()<>()
    @     0x7f84fcbe1b61 mrc::node::RxSinkBase<>::progress_engine()
    @     0x7f84fcbe12f7 _ZN5rxcpp12on_exceptionIZNKS_7sources6detail6createIN3mrc3rpc13ProgressEventEZNS4_4node10RxSinkBaseIS6_EC1EvEUlNS_10subscriberIS6_NS_8observerIS6_vvvvEEEEE_E12on_subscribeISD_EEvT_EUlvE_SD_EENSt9enable_ifIXsr13is_subscriberIT0_EE5valueENS_6detail17maybe_from_resultISH_E4typeEE4typeERKSH_RKSK_
    @     0x7f84fcbe11c5 _ZSt13__invoke_implIvRZN5rxcpp18dynamic_observableIN3mrc3rpc13ProgressEventEE9constructINS0_7sources6detail6createIS4_ZNS2_4node10RxSinkBaseIS4_EC1EvEUlNS0_10subscriberIS4_NS0_8observerIS4_vvvvEEEEE_EEEEvOT_ONS7_10tag_sourceEEUlSG_E_JSG_EESJ_St14__invoke_otherOT0_DpOT1_
    @     0x7f84fcbd8c6b rxcpp::detail::safe_subscriber<>::subscribe()
    @     0x7f84fcbdd43a rxcpp::schedulers::detail::action_tailrecurser::operator()()
    @     0x559f17344986 rxcpp::schedulers::current_thread::current_worker::schedule()
    @     0x7f84fcbd896b _ZNK5rxcpp10schedulers6worker8scheduleIRNS_6detail15safe_subscriberINS_18dynamic_observableIN3mrc3rpc13ProgressEventEEENS_10subscriberIS8_NS_8observerIS8_vvvvEEEEEEJEEENSt9enable_ifIXaaoosr6detail18is_action_functionIT_EE5valuesr15is_subscriptionISH_EE5valuentsr14is_schedulableISH_EE5valueEvE4typeEOSH_DpOT0_
    @     0x7f84fcbd84d7 rxcpp::observable<>::detail_subscribe<>()
    @     0x7f84fcbe5978 rxcpp::observable<>::subscribe<>()
    @     0x7f84fcbdef91 mrc::node::RxSink<>::do_subscribe()
    @     0x559f17337d04 mrc::node::RxRunnable<>::run()
    @     0x7f84fcbcfabe mrc::runnable::RunnableWithContext<>::main()
    @     0x7f84fcdcb9e5 std::_Function_handler<>::_M_invoke()
    @     0x7f84fccf5a76 boost::fibers::detail::task_object<>::run()
    @     0x7f84fccf5db2 _ZN5boost6fibers6detail11task_objectIZN3mrc4core14FiberTaskQueue7enqueueISt8functionIFvvEEJEEENS0_6futureINSt9result_ofIFT_DpT0_EE4typeEEEONS3_13FiberMetaDataEOSC_DpOSD_EUlvE_SaINS0_13packaged_taskIS8_EEEvJEE3runEv
    @     0x7f84fcd1409e boost::fibers::worker_context<>::run_()
    @     0x7f84fcd141bd boost::context::detail::fiber_entry<>()
    @     0x7f84fc4e511f make_fcontext
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
