### PR TITLE
Improve service shutdown

### DIFF
--- a/cpp/mrc/CMakeLists.txt
+++ b/cpp/mrc/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(libmrc
   src/internal/data_plane/server.cpp
   src/internal/executor/executor_definition.cpp
   src/internal/grpc/progress_engine.cpp
+  src/internal/grpc/promise_handler.cpp
   src/internal/grpc/server.cpp
   src/internal/memory/device_resources.cpp
   src/internal/memory/host_resources.cpp

--- a/cpp/mrc/include/mrc/core/userspace_threads.hpp
+++ b/cpp/mrc/include/mrc/core/userspace_threads.hpp
@@ -19,44 +19,51 @@
 
 #include <boost/fiber/all.hpp>
 
-namespace mrc {
+namespace mrc::userspace_threads {
 
-struct userspace_threads  // NOLINT
+// Suppress naming conventions in this file to allow matching std and boost libraries
+// NOLINTBEGIN(readability-identifier-naming)
+
+using mutex = boost::fibers::mutex;
+
+using recursive_mutex = boost::fibers::recursive_mutex;
+
+using cv = boost::fibers::condition_variable;
+
+using cv_any = boost::fibers::condition_variable_any;
+
+using launch = boost::fibers::launch;
+
+template <typename T>
+using promise = boost::fibers::promise<T>;
+
+template <typename T>
+using future = boost::fibers::future<T>;
+
+template <typename T>
+using shared_future = boost::fibers::shared_future<T>;
+
+template <typename SignatureT>
+using packaged_task = boost::fibers::packaged_task<SignatureT>;
+
+template <class Function, class... Args>
+static auto async(Function&& f, Args&&... args)
 {
-    using mutex = boost::fibers::mutex;  // NOLINT
+    return boost::fibers::async(f, std::forward<Args>(args)...);
+}
 
-    using cv = boost::fibers::condition_variable;  // NOLINT
+template <typename Rep, typename Period>
+static void sleep_for(std::chrono::duration<Rep, Period> const& timeout_duration)
+{
+    boost::this_fiber::sleep_for(timeout_duration);
+}
 
-    using launch = boost::fibers::launch;  // NOLINT
+template <typename Clock, typename Duration>
+static void sleep_until(std::chrono::time_point<Clock, Duration> const& sleep_time_point)
+{
+    boost::this_fiber::sleep_until(sleep_time_point);
+}
 
-    template <typename T>
-    using promise = boost::fibers::promise<T>;  // NOLINT
+// NOLINTEND(readability-identifier-naming)
 
-    template <typename T>
-    using future = boost::fibers::future<T>;  // NOLINT
-
-    template <typename T>
-    using shared_future = boost::fibers::shared_future<T>;  // NOLINT
-
-    template <class R, class... Args>                                // NOLINT
-    using packaged_task = boost::fibers::packaged_task<R(Args...)>;  // NOLINT
-
-    template <class Function, class... Args>  // NOLINT
-    static auto async(Function&& f, Args&&... args)
-    {
-        return boost::fibers::async(f, std::forward<Args>(args)...);
-    }
-
-    template <typename Rep, typename Period>  // NOLINT
-    static void sleep_for(std::chrono::duration<Rep, Period> const& timeout_duration)
-    {
-        boost::this_fiber::sleep_for(timeout_duration);
-    }
-
-    template <typename Clock, typename Duration>  // NOLINT
-    static void sleep_until(std::chrono::time_point<Clock, Duration> const& sleep_time_point)
-    {
-        boost::this_fiber::sleep_until(sleep_time_point);
-    }
-};
-}  // namespace mrc
+}  // namespace mrc::userspace_threads

--- a/cpp/mrc/include/mrc/types.hpp
+++ b/cpp/mrc/include/mrc/types.hpp
@@ -24,33 +24,40 @@
 
 namespace mrc {
 
+// Suppress naming conventions in this file to allow matching std and boost libraries
+// NOLINTBEGIN(readability-identifier-naming)
+
 // Typedefs
 template <typename T>
-using Promise = userspace_threads::promise<T>;  // NOLINT(readability-identifier-naming)
+using Promise = userspace_threads::promise<T>;
 
 template <typename T>
-using Future = userspace_threads::future<T>;  // NOLINT(readability-identifier-naming)
+using Future = userspace_threads::future<T>;
 
 template <typename T>
-using SharedFuture = userspace_threads::shared_future<T>;  // NOLINT(readability-identifier-naming)
+using SharedFuture = userspace_threads::shared_future<T>;
 
-using Mutex = userspace_threads::mutex;  // NOLINT(readability-identifier-naming)
+using Mutex = userspace_threads::mutex;
 
-using CondV = userspace_threads::cv;  // NOLINT(readability-identifier-naming)
+using RecursiveMutex = userspace_threads::recursive_mutex;
 
-using MachineID  = std::uint64_t;  // NOLINT(readability-identifier-naming)
-using InstanceID = std::uint64_t;  // NOLINT(readability-identifier-naming)
-using TagID      = std::uint64_t;  // NOLINT(readability-identifier-naming)
+using CondV = userspace_threads::cv;
+
+using MachineID  = std::uint64_t;
+using InstanceID = std::uint64_t;
+using TagID      = std::uint64_t;
 
 template <typename T>
-using Handle = std::shared_ptr<T>;  // NOLINT(readability-identifier-naming)
+using Handle = std::shared_ptr<T>;
 
-using SegmentID      = std::uint16_t;  // NOLINT(readability-identifier-naming)
-using SegmentRank    = std::uint16_t;  // NOLINT(readability-identifier-naming)
-using SegmentAddress = std::uint32_t;  // NOLINT(readability-identifier-naming) // id + rank
+using SegmentID      = std::uint16_t;
+using SegmentRank    = std::uint16_t;
+using SegmentAddress = std::uint32_t;  // id + rank
 
-using PortName    = std::string;    // NOLINT(readability-identifier-naming)
-using PortID      = std::uint16_t;  // NOLINT(readability-identifier-naming)
-using PortAddress = std::uint64_t;  // NOLINT(readability-identifier-naming)  // id + rank + port
+using PortName    = std::string;
+using PortID      = std::uint16_t;
+using PortAddress = std::uint64_t;  // id + rank + port
+
+// NOLINTEND(readability-identifier-naming)
 
 }  // namespace mrc

--- a/cpp/mrc/src/internal/control_plane/client.cpp
+++ b/cpp/mrc/src/internal/control_plane/client.cpp
@@ -49,12 +49,14 @@ std::atomic_uint64_t AsyncEventStatus::s_request_id_counter;
 
 Client::Client(resources::PartitionResourceBase& base, std::shared_ptr<grpc::CompletionQueue> cq) :
   resources::PartitionResourceBase(base),
+  Service("control_plane::Client"),
   m_cq(std::move(cq)),
   m_owns_progress_engine(false)
 {}
 
 Client::Client(resources::PartitionResourceBase& base) :
   resources::PartitionResourceBase(base),
+  Service("control_plane::Client"),
   m_cq(std::make_shared<grpc::CompletionQueue>()),
   m_owns_progress_engine(true)
 {}

--- a/cpp/mrc/src/internal/control_plane/client.cpp
+++ b/cpp/mrc/src/internal/control_plane/client.cpp
@@ -49,14 +49,12 @@ std::atomic_uint64_t AsyncEventStatus::s_request_id_counter;
 
 Client::Client(resources::PartitionResourceBase& base, std::shared_ptr<grpc::CompletionQueue> cq) :
   resources::PartitionResourceBase(base),
-  Service(__FILE__),
   m_cq(std::move(cq)),
   m_owns_progress_engine(false)
 {}
 
 Client::Client(resources::PartitionResourceBase& base) :
   resources::PartitionResourceBase(base),
-  Service(__FILE__),
   m_cq(std::make_shared<grpc::CompletionQueue>()),
   m_owns_progress_engine(true)
 {}

--- a/cpp/mrc/src/internal/control_plane/client.hpp
+++ b/cpp/mrc/src/internal/control_plane/client.hpp
@@ -24,6 +24,7 @@
 #include "internal/service.hpp"
 
 #include "mrc/core/error.hpp"
+#include "mrc/exceptions/runtime_error.hpp"
 #include "mrc/node/forward.hpp"
 #include "mrc/node/writable_entrypoint.hpp"
 #include "mrc/protos/architect.grpc.pb.h"
@@ -35,6 +36,7 @@
 #include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 
+#include <atomic>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -67,8 +69,54 @@ class Runner;
 
 namespace mrc::control_plane {
 
-template <typename ResponseT>
-class AsyncStatus;
+class AsyncEventStatus
+{
+  public:
+    size_t request_id() const
+    {
+        return m_request_id;
+    }
+
+    template <typename ResponseT>
+    Expected<ResponseT> await_response()
+    {
+        if (!m_future.valid())
+        {
+            throw exceptions::MrcRuntimeError(
+                "This AsyncEventStatus is not expecting a response or the response has already been awaited");
+        }
+
+        auto event = m_future.get();
+
+        if (event.has_error())
+        {
+            return Error::create(event.error().message());
+        }
+
+        ResponseT response;
+        if (!event.message().UnpackTo(&response))
+        {
+            throw Error::create("fatal error: unable to unpack message; server sent the wrong message type");
+        }
+
+        return response;
+    }
+
+  private:
+    AsyncEventStatus() : m_request_id(++s_request_id_counter) {}
+
+    void set_future(Future<protos::Event> future)
+    {
+        m_future = std::move(future);
+    }
+
+    static std::atomic_uint64_t s_request_id_counter;
+
+    size_t m_request_id;
+    Future<protos::Event> m_future;
+
+    friend class Client;
+};
 
 /**
  * @brief Primary Control Plane Client
@@ -128,13 +176,13 @@ class Client final : public resources::PartitionResourceBase, public Service
     template <typename ResponseT, typename RequestT>
     Expected<ResponseT> await_unary(const protos::EventType& event_type, RequestT&& request);
 
-    template <typename ResponseT, typename RequestT>
-    void async_unary(const protos::EventType& event_type, RequestT&& request, AsyncStatus<ResponseT>& status);
+    template <typename RequestT>
+    AsyncEventStatus async_unary(const protos::EventType& event_type, RequestT&& request);
 
     template <typename MessageT>
-    void issue_event(const protos::EventType& event_type, MessageT&& message);
+    AsyncEventStatus issue_event(const protos::EventType& event_type, MessageT&& message);
 
-    void issue_event(const protos::EventType& event_type);
+    AsyncEventStatus issue_event(const protos::EventType& event_type);
 
     bool has_subscription_service(const std::string& name) const;
 
@@ -150,6 +198,8 @@ class Client final : public resources::PartitionResourceBase, public Service
     void request_update();
 
   private:
+    AsyncEventStatus write_event(protos::Event event, bool await_response = false);
+
     void route_state_update(std::uint64_t tag, protos::StateUpdate&& update);
 
     void do_service_start() final;
@@ -201,70 +251,39 @@ class Client final : public resources::PartitionResourceBase, public Service
 
     std::mutex m_mutex;
 
+    std::map<size_t, Promise<protos::Event>> m_pending_events;
+
     friend network::NetworkResources;
 };
 
 // todo: create this object from the client which will own the stop_source
 // create this object with a stop_token associated with the client's stop_source
 
-template <typename ResponseT>
-class AsyncStatus
-{
-  public:
-    AsyncStatus() = default;
-
-    DELETE_COPYABILITY(AsyncStatus);
-    DELETE_MOVEABILITY(AsyncStatus);
-
-    Expected<ResponseT> await_response()
-    {
-        // todo(ryan): expand this into a wait_until with a deadline and a stop token
-        auto event = m_promise.get_future().get();
-
-        if (event.has_error())
-        {
-            return Error::create(event.error().message());
-        }
-
-        ResponseT response;
-        if (!event.message().UnpackTo(&response))
-        {
-            throw Error::create("fatal error: unable to unpack message; server sent the wrong message type");
-        }
-
-        return response;
-    }
-
-  private:
-    Promise<protos::Event> m_promise;
-    friend Client;
-};
-
 template <typename ResponseT, typename RequestT>
 Expected<ResponseT> Client::await_unary(const protos::EventType& event_type, RequestT&& request)
 {
-    AsyncStatus<ResponseT> status;
-    async_unary(event_type, std::move(request), status);
-    return status.await_response();
+    auto status = this->async_unary(event_type, std::move(request));
+    return status.template await_response<ResponseT>();
 }
 
-template <typename ResponseT, typename RequestT>
-void Client::async_unary(const protos::EventType& event_type, RequestT&& request, AsyncStatus<ResponseT>& status)
+template <typename RequestT>
+AsyncEventStatus Client::async_unary(const protos::EventType& event_type, RequestT&& request)
 {
     protos::Event event;
     event.set_event(event_type);
-    event.set_tag(reinterpret_cast<std::uint64_t>(&status.m_promise));
     CHECK(event.mutable_message()->PackFrom(request));
-    m_writer->await_write(std::move(event));
+
+    return this->write_event(std::move(event), true);
 }
 
 template <typename MessageT>
-void Client::issue_event(const protos::EventType& event_type, MessageT&& message)
+AsyncEventStatus Client::issue_event(const protos::EventType& event_type, MessageT&& message)
 {
     protos::Event event;
     event.set_event(event_type);
     CHECK(event.mutable_message()->PackFrom(message));
-    m_writer->await_write(std::move(event));
+
+    return this->write_event(std::move(event), false);
 }
 
 }  // namespace mrc::control_plane

--- a/cpp/mrc/src/internal/control_plane/client/instance.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/instance.cpp
@@ -49,6 +49,7 @@ Instance::Instance(Client& client,
                    resources::PartitionResourceBase& base,
                    mrc::edge::IWritableAcceptor<const protos::StateUpdate>& update_channel) :
   resources::PartitionResourceBase(base),
+  Service("control_plane::client::Instance"),
   m_client(client),
   m_instance_id(instance_id)
 {

--- a/cpp/mrc/src/internal/control_plane/client/subscription_service.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/subscription_service.cpp
@@ -34,6 +34,7 @@
 namespace mrc::control_plane::client {
 
 SubscriptionService::SubscriptionService(const std::string& service_name, Instance& instance) :
+  Service("control_plane::client::SubscriptionService"),
   m_service_name(std::move(service_name)),
   m_instance(instance)
 {

--- a/cpp/mrc/src/internal/control_plane/server.cpp
+++ b/cpp/mrc/src/internal/control_plane/server.cpp
@@ -86,7 +86,11 @@ static Expected<> unary_response(Server::event_t& event, Expected<MessageT>&& me
     return {};
 }
 
-Server::Server(runnable::RunnableResources& runnable) : m_runnable(runnable), m_server(m_runnable) {}
+Server::Server(runnable::RunnableResources& runnable) :
+  Service("control_plane::Server"),
+  m_runnable(runnable),
+  m_server(m_runnable)
+{}
 
 Server::~Server() = default;
 

--- a/cpp/mrc/src/internal/control_plane/server.cpp
+++ b/cpp/mrc/src/internal/control_plane/server.cpp
@@ -92,7 +92,10 @@ Server::Server(runnable::RunnableResources& runnable) :
   m_server(m_runnable)
 {}
 
-Server::~Server() = default;
+Server::~Server()
+{
+    Service::call_in_destructor();
+}
 
 void Server::do_service_start()
 {

--- a/cpp/mrc/src/internal/data_plane/client.cpp
+++ b/cpp/mrc/src/internal/data_plane/client.cpp
@@ -25,6 +25,7 @@
 #include "internal/memory/transient_pool.hpp"
 #include "internal/remote_descriptor/manager.hpp"
 #include "internal/runnable/runnable_resources.hpp"
+#include "internal/service.hpp"
 #include "internal/ucx/common.hpp"
 #include "internal/ucx/endpoint.hpp"
 #include "internal/ucx/ucx_resources.hpp"
@@ -71,7 +72,10 @@ Client::Client(resources::PartitionResourceBase& base,
   m_rd_channel(std::make_unique<node::NodeComponent<RemoteDescriptorMessage>>())
 {}
 
-Client::~Client() = default;
+Client::~Client()
+{
+    Service::call_in_destructor();
+}
 
 std::shared_ptr<ucx::Endpoint> Client::endpoint_shared(const InstanceID& id) const
 {

--- a/cpp/mrc/src/internal/data_plane/client.cpp
+++ b/cpp/mrc/src/internal/data_plane/client.cpp
@@ -64,6 +64,7 @@ Client::Client(resources::PartitionResourceBase& base,
                control_plane::client::ConnectionsManager& connections_manager,
                memory::TransientPool& transient_pool) :
   resources::PartitionResourceBase(base),
+  Service("data_plane::Client"),
   m_ucx(ucx),
   m_connnection_manager(connections_manager),
   m_transient_pool(transient_pool),

--- a/cpp/mrc/src/internal/data_plane/data_plane_resources.cpp
+++ b/cpp/mrc/src/internal/data_plane/data_plane_resources.cpp
@@ -38,6 +38,7 @@ DataPlaneResources::DataPlaneResources(resources::PartitionResourceBase& base,
                                        const InstanceID& instance_id,
                                        control_plane::Client& control_plane_client) :
   resources::PartitionResourceBase(base),
+  Service("DataPlaneResources"),
   m_ucx(ucx),
   m_host(host),
   m_control_plane_client(control_plane_client),

--- a/cpp/mrc/src/internal/data_plane/server.cpp
+++ b/cpp/mrc/src/internal/data_plane/server.cpp
@@ -148,6 +148,7 @@ Server::Server(resources::PartitionResourceBase& provider,
                memory::TransientPool& transient_pool,
                InstanceID instance_id) :
   resources::PartitionResourceBase(provider),
+  Service("data_plane::Server"),
   m_ucx(ucx),
   m_host(host),
   m_instance_id(instance_id),

--- a/cpp/mrc/src/internal/executor/executor_definition.cpp
+++ b/cpp/mrc/src/internal/executor/executor_definition.cpp
@@ -129,7 +129,6 @@ void ExecutorDefinition::join()
 void ExecutorDefinition::do_service_start()
 {
     CHECK(m_pipeline_manager);
-    m_pipeline_manager->service_start();
 
     pipeline::SegmentAddresses initial_segments;
     for (const auto& [id, segment] : m_pipeline_manager->pipeline().segments())

--- a/cpp/mrc/src/internal/executor/executor_definition.cpp
+++ b/cpp/mrc/src/internal/executor/executor_definition.cpp
@@ -76,6 +76,7 @@ static bool valid_pipeline(const pipeline::PipelineDefinition& pipeline)
 
 ExecutorDefinition::ExecutorDefinition(std::unique_ptr<system::SystemDefinition> system) :
   SystemProvider(std::move(system)),
+  Service("ExecutorDefinition"),
   m_resources_manager(std::make_unique<resources::Manager>(*this))
 {}
 

--- a/cpp/mrc/src/internal/grpc/client_streaming.hpp
+++ b/cpp/mrc/src/internal/grpc/client_streaming.hpp
@@ -152,6 +152,7 @@ class ClientStream : private Service, public std::enable_shared_from_this<Client
         std::function<std::unique_ptr<grpc::ClientAsyncReaderWriter<RequestT, ResponseT>>(grpc::ClientContext* context)>;
 
     ClientStream(prepare_fn_t prepare_fn, runnable::RunnableResources& runnable) :
+      Service("rpc::ClientStream"),
       m_prepare_fn(prepare_fn),
       m_runnable(runnable),
       m_reader_source(std::make_unique<mrc::node::RxSource<IncomingData>>(

--- a/cpp/mrc/src/internal/grpc/progress_engine.cpp
+++ b/cpp/mrc/src/internal/grpc/progress_engine.cpp
@@ -40,6 +40,9 @@ void ProgressEngine::data_source(rxcpp::subscriber<ProgressEvent>& s)
 
     while (s.is_subscribed())
     {
+        event.ok  = false;
+        event.tag = nullptr;
+
         switch (m_cq->AsyncNext<gpr_timespec>(&event.tag, &event.ok, gpr_time_0(GPR_CLOCK_REALTIME)))
         {
         case grpc::CompletionQueue::NextStatus::GOT_EVENT: {

--- a/cpp/mrc/src/internal/grpc/promise_handler.cpp
+++ b/cpp/mrc/src/internal/grpc/promise_handler.cpp
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "internal/grpc/promise_handler.hpp"
+
+#include "internal/resources/manager.hpp"
+
+#include "mrc/exceptions/runtime_error.hpp"
+
+#include <atomic>
+#include <mutex>
+
+namespace mrc::rpc {
+
+std::atomic_size_t PromiseWrapper::s_id_counter = 0;
+
+PromiseWrapper::PromiseWrapper(const std::string& method, bool in_runtime) : id(++s_id_counter), method(method)
+{
+    size_t runtime_id = 0;
+
+    // try
+    // {
+    //     runtime_id = resources::Manager::get_resources().runtime_id();
+    // } catch (exceptions::MrcRuntimeError& e)
+    // {
+    //     // Do nothing for now
+    // }
+
+    this->prefix = MRC_CONCAT_STR("Promise[" << id << ", " << this << ", " << runtime_id << "](" << method << "): ");
+    VLOG(5) << this->to_string() << "#1 creating promise";
+}
+
+PromiseWrapper::~PromiseWrapper()
+{
+    // VLOG(5) << this->to_string() << "#5 deleting promise";
+}
+
+void PromiseWrapper::set_value(bool val)
+{
+    auto tmp_prefix = this->to_string();
+
+    // Acquire the mutex to prevent leaving `get_future` before we exit
+    // std::unique_lock lock(m_mutex);
+
+    VLOG(5) << tmp_prefix << "#2 setting promise to " << val;
+    this->promise.set_value(val);
+    VLOG(5) << tmp_prefix << "#3 setting promise to " << val << "... done";
+}
+
+bool PromiseWrapper::get_future()
+{
+    auto future = this->promise.get_future();
+
+    auto value = future.get();
+
+    VLOG(5) << this->to_string() << "#4 got future with value " << value;
+
+    // Before exiting, we must acquire the mutex to prevent this object being cleaned up
+    // std::unique_lock lock(m_mutex);
+
+    return value;
+}
+
+std::string PromiseWrapper::to_string() const
+{
+    return this->prefix;
+    // return MRC_CONCAT_STR("Promise[" << id << "](" << method << "): ");
+}
+
+}  // namespace mrc::rpc

--- a/cpp/mrc/src/internal/grpc/promise_handler.hpp
+++ b/cpp/mrc/src/internal/grpc/promise_handler.hpp
@@ -20,10 +20,37 @@
 #include "internal/grpc/progress_engine.hpp"
 
 #include "mrc/node/generic_sink.hpp"
+#include "mrc/utils/string_utils.hpp"
 
 #include <boost/fiber/all.hpp>
+#include <boost/fiber/mutex.hpp>
+
+#include <string>
 
 namespace mrc::rpc {
+
+struct PromiseWrapper
+{
+    PromiseWrapper(const std::string& method, bool in_runtime = true);
+
+    ~PromiseWrapper();
+
+    size_t id;
+    std::string method;
+    std::string prefix;
+    boost::fibers::promise<bool> promise;
+
+    void set_value(bool val);
+
+    bool get_future();
+
+    std::string to_string() const;
+
+  private:
+    boost::fibers::mutex m_mutex;
+
+    static std::atomic_size_t s_id_counter;
+};
 
 /**
  * @brief MRC Sink to handle ProgressEvents which correspond to Promise<bool> tags
@@ -32,7 +59,8 @@ class PromiseHandler final : public mrc::node::GenericSink<ProgressEvent>
 {
     void on_data(ProgressEvent&& event) final
     {
-        auto* promise = static_cast<boost::fibers::promise<bool>*>(event.tag);
+        auto* promise = static_cast<PromiseWrapper*>(event.tag);
+
         promise->set_value(event.ok);
     }
 };

--- a/cpp/mrc/src/internal/grpc/server.cpp
+++ b/cpp/mrc/src/internal/grpc/server.cpp
@@ -31,7 +31,7 @@
 
 namespace mrc::rpc {
 
-Server::Server(runnable::RunnableResources& runnable) : m_runnable(runnable)
+Server::Server(runnable::RunnableResources& runnable) : Service("rpc::Server"), m_runnable(runnable)
 {
     m_cq = m_builder.AddCompletionQueue();
     m_builder.AddListeningPort("0.0.0.0:13337", grpc::InsecureServerCredentials());

--- a/cpp/mrc/src/internal/grpc/server_streaming.hpp
+++ b/cpp/mrc/src/internal/grpc/server_streaming.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "internal/grpc/progress_engine.hpp"
+#include "internal/grpc/promise_handler.hpp"
 #include "internal/grpc/stream_writer.hpp"
 #include "internal/runnable/runnable_resources.hpp"
 #include "internal/service.hpp"
@@ -224,10 +225,11 @@ class ServerStream : private Service, public std::enable_shared_from_this<Server
         while (s.is_subscribed())
         {
             CHECK(m_stream);
-            Promise<bool> read;
+
             IncomingData data;
-            m_stream->Read(&data.msg, &read);
-            auto ok     = read.get_future().get();
+            PromiseWrapper wrapper("Server::Read");
+            m_stream->Read(&data.msg, &wrapper);
+            auto ok     = wrapper.get_future();
             data.ok     = ok;
             data.stream = writer();
             s.on_next(std::move(data));
@@ -248,9 +250,9 @@ class ServerStream : private Service, public std::enable_shared_from_this<Server
         CHECK(m_stream);
         if (m_can_write)
         {
-            Promise<bool> promise;
-            m_stream->Write(request, &promise);
-            auto ok = promise.get_future().get();
+            PromiseWrapper wrapper("Server::Write");
+            m_stream->Write(request, &wrapper);
+            auto ok = wrapper.get_future();
             if (!ok)
             {
                 DVLOG(10) << "server failed to write to client; disabling writes and beginning shutdown";
@@ -273,10 +275,10 @@ class ServerStream : private Service, public std::enable_shared_from_this<Server
             }
 
             DVLOG(10) << "server issuing finish";
-            Promise<bool> finish;
-            m_stream->Finish(*m_status, &finish);
-            auto ok = finish.get_future().get();
-            DVLOG(10) << "server done with finish";
+            PromiseWrapper wrapper("Server::Finish");
+            m_stream->Finish(*m_status, &wrapper);
+            auto ok = wrapper.get_future();
+            // DVLOG(10) << "server done with finish";
         }
     }
 
@@ -318,10 +320,9 @@ class ServerStream : private Service, public std::enable_shared_from_this<Server
 
     void do_service_start() final
     {
-        Promise<bool> promise;
-        m_init_fn(&promise);
-        auto ok = promise.get_future().get();
-
+        PromiseWrapper wrapper("Server::m_init_fn");
+        m_init_fn(&wrapper);
+        auto ok = wrapper.get_future();
         if (!ok)
         {
             DVLOG(10) << "server stream could not be initialized";

--- a/cpp/mrc/src/internal/grpc/server_streaming.hpp
+++ b/cpp/mrc/src/internal/grpc/server_streaming.hpp
@@ -164,6 +164,7 @@ class ServerStream : private Service, public std::enable_shared_from_this<Server
         void(grpc::ServerContext* context, grpc::ServerAsyncReaderWriter<ResponseT, RequestT>* stream, void* tag)>;
 
     ServerStream(request_fn_t request_fn, runnable::RunnableResources& runnable) :
+      Service("rpc::ServerStream"),
       m_runnable(runnable),
       m_stream(std::make_unique<grpc::ServerAsyncReaderWriter<ResponseT, RequestT>>(&m_context)),
       m_reader_source(std::make_unique<mrc::node::RxSource<IncomingData>>(

--- a/cpp/mrc/src/internal/pipeline/manager.cpp
+++ b/cpp/mrc/src/internal/pipeline/manager.cpp
@@ -44,6 +44,7 @@
 namespace mrc::pipeline {
 
 Manager::Manager(std::shared_ptr<PipelineDefinition> pipeline, resources::Manager& resources) :
+  Service("pipeline::Manager"),
   m_pipeline(std::move(pipeline)),
   m_resources(resources)
 {

--- a/cpp/mrc/src/internal/pipeline/pipeline_instance.cpp
+++ b/cpp/mrc/src/internal/pipeline/pipeline_instance.cpp
@@ -24,6 +24,7 @@
 #include "internal/runnable/runnable_resources.hpp"
 #include "internal/segment/segment_definition.hpp"
 #include "internal/segment/segment_instance.hpp"
+#include "internal/service.hpp"
 
 #include "mrc/core/addresses.hpp"
 #include "mrc/core/task_queue.hpp"
@@ -53,7 +54,10 @@ PipelineInstance::PipelineInstance(std::shared_ptr<const PipelineDefinition> def
     m_joinable_future = m_joinable_promise.get_future().share();
 }
 
-PipelineInstance::~PipelineInstance() = default;
+PipelineInstance::~PipelineInstance()
+{
+    Service::call_in_destructor();
+}
 
 void PipelineInstance::update()
 {

--- a/cpp/mrc/src/internal/pipeline/pipeline_instance.cpp
+++ b/cpp/mrc/src/internal/pipeline/pipeline_instance.cpp
@@ -46,6 +46,7 @@ namespace mrc::pipeline {
 PipelineInstance::PipelineInstance(std::shared_ptr<const PipelineDefinition> definition,
                                    resources::Manager& resources) :
   PipelineResources(resources),
+  Service("pipeline::PipelineInstance"),
   m_definition(std::move(definition))
 {
     CHECK(m_definition);

--- a/cpp/mrc/src/internal/remote_descriptor/manager.cpp
+++ b/cpp/mrc/src/internal/remote_descriptor/manager.cpp
@@ -86,6 +86,7 @@ ucs_status_t active_message_callback(void* arg,
 }  // namespace
 
 Manager::Manager(const InstanceID& instance_id, resources::PartitionResources& resources) :
+  Service("remote_descriptor::Manager"),
   m_instance_id(instance_id),
   m_resources(resources)
 {

--- a/cpp/mrc/src/internal/resources/manager.cpp
+++ b/cpp/mrc/src/internal/resources/manager.cpp
@@ -45,6 +45,7 @@
 #include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 
+#include <atomic>
 #include <map>
 #include <optional>
 #include <ostream>
@@ -54,16 +55,18 @@
 
 namespace mrc::resources {
 
+std::atomic_size_t Manager::s_id_counter = 0;
 thread_local Manager* Manager::m_thread_resources{nullptr};
 thread_local PartitionResources* Manager::m_thread_partition{nullptr};
 
 Manager::Manager(const system::SystemProvider& system) :
   SystemProvider(system),
+  m_runtime_id(++s_id_counter),
   m_threading(std::make_unique<system::ThreadingResources>(system))
 {
     const auto& partitions      = this->system().partitions().flattened();
     const auto& host_partitions = this->system().partitions().host_partitions();
-    const bool network_enabled  = !this->system().options().architect_url().empty();
+    bool network_enabled        = !this->system().options().architect_url().empty();
 
     // construct the runnable resources on each host_partition - launch control and main
     for (std::size_t i = 0; i < host_partitions.size(); ++i)
@@ -195,6 +198,11 @@ Manager::Manager(const system::SystemProvider& system) :
 Manager::~Manager()
 {
     m_network.clear();
+}
+
+std::size_t Manager::runtime_id() const
+{
+    return m_runtime_id;
 }
 
 std::size_t Manager::partition_count() const

--- a/cpp/mrc/src/internal/resources/manager.hpp
+++ b/cpp/mrc/src/internal/resources/manager.hpp
@@ -24,6 +24,7 @@
 
 #include "mrc/types.hpp"
 
+#include <atomic>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -57,6 +58,8 @@ class Manager final : public system::SystemProvider
     // Manager(std::unique_ptr<system::ThreadingResources> resources);
     ~Manager() override;
 
+    std::size_t runtime_id() const;
+
     static Manager& get_resources();
     static PartitionResources& get_partition();
 
@@ -67,6 +70,8 @@ class Manager final : public system::SystemProvider
 
   private:
     Future<void> shutdown();
+
+    const size_t m_runtime_id;  // unique id for this runtime
 
     const std::unique_ptr<system::ThreadingResources> m_threading;
     std::vector<runnable::RunnableResources> m_runnable;  // one per host partition
@@ -82,6 +87,7 @@ class Manager final : public system::SystemProvider
     // which must be destroyed before all other
     std::vector<std::optional<network::NetworkResources>> m_network;  // one per flattened partition
 
+    static std::atomic_size_t s_id_counter;
     static thread_local PartitionResources* m_thread_partition;
     static thread_local Manager* m_thread_resources;
 

--- a/cpp/mrc/src/internal/segment/segment_instance.cpp
+++ b/cpp/mrc/src/internal/segment/segment_instance.cpp
@@ -54,6 +54,7 @@ SegmentInstance::SegmentInstance(std::shared_ptr<const SegmentDefinition> defini
                                  SegmentRank rank,
                                  pipeline::PipelineResources& resources,
                                  std::size_t partition_id) :
+  Service("segment::SegmentInstance"),
   m_name(definition->name()),
   m_id(definition->id()),
   m_rank(rank),

--- a/cpp/mrc/src/internal/segment/segment_instance.cpp
+++ b/cpp/mrc/src/internal/segment/segment_instance.cpp
@@ -79,7 +79,10 @@ SegmentInstance::SegmentInstance(std::shared_ptr<const SegmentDefinition> defini
                     .get();
 }
 
-SegmentInstance::~SegmentInstance() = default;
+SegmentInstance::~SegmentInstance()
+{
+    Service::call_in_destructor();
+}
 
 const std::string& SegmentInstance::name() const
 {

--- a/cpp/mrc/src/internal/service.cpp
+++ b/cpp/mrc/src/internal/service.cpp
@@ -23,6 +23,7 @@
 
 #include <glog/logging.h>
 
+#include <exception>
 #include <future>
 #include <mutex>
 #include <ostream>
@@ -222,8 +223,9 @@ void Service::service_await_join()
                 // Set the value only if there was not an exception
                 completed_promise.set_value();
 
-            } catch (...)
+            } catch (const std::exception& ex)
             {
+                LOG(ERROR) << this->debug_prefix() << " caught exception in service_await_join: " << ex.what();
                 // Join must have thrown, set the exception in the promise (it will be retrieved later)
                 completed_promise.set_exception(std::current_exception());
             }

--- a/cpp/mrc/src/internal/service.hpp
+++ b/cpp/mrc/src/internal/service.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "mrc/types.hpp"
+
 #include <mutex>
 #include <string>
 
@@ -25,28 +27,65 @@ namespace mrc {
 enum class ServiceState
 {
     Initialized,
+    Starting,
     Running,
-    Awaiting,
     Stopping,
     Killing,
     Completed,
 };
 
-// struct IService
-// {
-//     virtual ~IService() = default;
+/**
+ * @brief Converts a `AsyncServiceState` enum to a string
+ *
+ * @param f
+ * @return std::string
+ */
+inline std::string servicestate_to_str(const ServiceState& s)
+{
+    switch (s)
+    {
+    case ServiceState::Initialized:
+        return "Initialized";
+    case ServiceState::Starting:
+        return "Starting";
+    case ServiceState::Running:
+        return "Running";
+    case ServiceState::Stopping:
+        return "Stopping";
+    case ServiceState::Killing:
+        return "Killing";
+    case ServiceState::Completed:
+        return "Completed";
+    default:
+        throw std::logic_error("Unsupported ServiceState enum. Was a new value added recently?");
+    }
+}
 
-//     virtual void service_start()      = 0;
-//     virtual void service_await_live() = 0;
-//     virtual void service_stop()       = 0;
-//     virtual void service_kill()       = 0;
-//     virtual void service_await_join() = 0;
-// };
+/**
+ * @brief Stream operator for `AsyncServiceState`
+ *
+ * @param os
+ * @param f
+ * @return std::ostream&
+ */
+static inline std::ostream& operator<<(std::ostream& os, const ServiceState& f)
+{
+    os << servicestate_to_str(f);
+    return os;
+}
 
-class Service  // : public IService
+class Service
 {
   public:
     virtual ~Service();
+
+    const std::string& service_name() const;
+
+    bool is_service_startable() const;
+
+    bool is_running() const;
+
+    const ServiceState& state() const;
 
     void service_start();
     void service_await_live();
@@ -54,15 +93,24 @@ class Service  // : public IService
     void service_kill();
     void service_await_join();
 
-    bool is_service_startable() const;
-    const ServiceState& state() const;
-
   protected:
+    Service(std::string service_name);
+
+    // Prefix to use for debug messages. Contains useful information about the service
+    std::string debug_prefix() const;
+
     void call_in_destructor();
     void service_set_description(std::string description);
 
   private:
-    bool forward_state(ServiceState new_state);
+    // Advances the state. New state value must be greater than or equal to current state. Using a value less than the
+    // current state will generate an error. Use assert_forward = false to require that the state advances. Normally,
+    // same states are fine
+    bool forward_state(ServiceState new_state, bool assert_forward = false);
+
+    // Ensures the state is at least the current value or higher. Does not change the state if the value is less than or
+    // equal the current state
+    bool ensure_state(ServiceState ensure_state);
 
     virtual void do_service_start()      = 0;
     virtual void do_service_await_live() = 0;
@@ -71,8 +119,21 @@ class Service  // : public IService
     virtual void do_service_await_join() = 0;
 
     ServiceState m_state{ServiceState::Initialized};
-    std::string m_description{"mrc::service"};
-    mutable std::mutex m_mutex;
+    std::string m_service_name{"mrc::Service"};
+
+    // This future is set in `service_await_live` and is used to wait for the service to to be live. We use a future
+    // here incase it is called multiple times, they will all be released when the service is live.
+    SharedFuture<void> m_live_future;
+
+    // This future is set in `service_await_join` and is used to wait for the service to complete. We use a future here
+    // incase join is called multiple times, they will all be released when the service completes.
+    SharedFuture<void> m_completed_future;
+
+    bool m_service_await_live_called{false};
+    bool m_service_await_join_called{false};
+    bool m_call_in_destructor_called{false};
+
+    mutable RecursiveMutex m_mutex;
 };
 
 }  // namespace mrc

--- a/cpp/mrc/src/internal/system/fiber_manager.cpp
+++ b/cpp/mrc/src/internal/system/fiber_manager.cpp
@@ -26,9 +26,11 @@
 #include "mrc/exceptions/runtime_error.hpp"
 #include "mrc/options/fiber_pool.hpp"
 #include "mrc/options/options.hpp"
+#include "mrc/utils/string_utils.hpp"
 
 #include <functional>
 #include <memory>
+#include <sstream>
 
 namespace mrc::system {
 
@@ -44,7 +46,7 @@ FiberManager::FiberManager(const ThreadingResources& resources) : m_cpu_set(reso
 
     topology.cpu_set().for_each_bit([&](std::int32_t idx, std::int32_t cpu_id) {
         DVLOG(10) << "initializing fiber queue " << idx << " of " << cpu_count << " on cpu_id " << cpu_id;
-        m_queues[cpu_id] = std::make_unique<FiberTaskQueue>(resources, cpu_id);
+        m_queues[cpu_id] = std::make_unique<FiberTaskQueue>(resources, cpu_id, MRC_CONCAT_STR("fibq[" << idx << "]"));
     });
 }
 

--- a/cpp/mrc/src/internal/system/fiber_task_queue.cpp
+++ b/cpp/mrc/src/internal/system/fiber_task_queue.cpp
@@ -39,12 +39,16 @@
 
 namespace mrc::system {
 
-FiberTaskQueue::FiberTaskQueue(const ThreadingResources& resources, CpuSet cpu_affinity, std::size_t channel_size) :
+FiberTaskQueue::FiberTaskQueue(const ThreadingResources& resources,
+                               CpuSet cpu_affinity,
+                               std::string thread_name,
+                               std::size_t channel_size) :
   m_queue(channel_size),
   m_cpu_affinity(std::move(cpu_affinity)),
-  m_thread(resources.make_thread("fiberq", m_cpu_affinity, [this] {
+  m_thread(resources.make_thread(std::move(thread_name), m_cpu_affinity, [this] {
       main();
   }))
+
 {
     DVLOG(10) << "awaiting fiber task queue worker thread running on cpus " << m_cpu_affinity;
     enqueue([] {}).get();
@@ -106,7 +110,7 @@ void FiberTaskQueue::launch(task_pkg_t&& pkg) const
     boost::fibers::fiber fiber(std::move(pkg.first));
     auto& props(fiber.properties<FiberPriorityProps>());
     props.set_priority(pkg.second.priority);
-    DVLOG(10) << *this << ": created fiber " << fiber.get_id() << " with priority " << pkg.second.priority;
+    DVLOG(20) << *this << ": created fiber " << fiber.get_id() << " with priority " << pkg.second.priority;
     fiber.detach();
 }
 

--- a/cpp/mrc/src/internal/system/fiber_task_queue.hpp
+++ b/cpp/mrc/src/internal/system/fiber_task_queue.hpp
@@ -36,7 +36,10 @@ class ThreadingResources;
 class FiberTaskQueue final : public core::FiberTaskQueue
 {
   public:
-    FiberTaskQueue(const ThreadingResources& resources, CpuSet cpu_affinity, std::size_t channel_size = 64);
+    FiberTaskQueue(const ThreadingResources& resources,
+                   CpuSet cpu_affinity,
+                   std::string thread_name,
+                   std::size_t channel_size = 64);
     ~FiberTaskQueue() final;
 
     DELETE_COPYABILITY(FiberTaskQueue);

--- a/cpp/mrc/src/internal/system/thread.cpp
+++ b/cpp/mrc/src/internal/system/thread.cpp
@@ -90,13 +90,13 @@ void ThreadResources::initialize_thread(const std::string& desc, const CpuSet& c
     {
         std::stringstream ss;
         ss << "cpu_id: " << cpu_affinity.first();
-        affinity = ss.str();
+        affinity = MRC_CONCAT_STR("cpu[" << cpu_affinity.str() << "]");
     }
     else
     {
         std::stringstream ss;
         ss << "cpus: " << cpu_affinity.str();
-        affinity      = ss.str();
+        affinity      = MRC_CONCAT_STR("cpu[" << cpu_affinity.str() << "]");
         auto numa_set = topology.numaset_for_cpuset(cpu_affinity);
         if (numa_set.weight() != 1)
         {
@@ -110,13 +110,13 @@ void ThreadResources::initialize_thread(const std::string& desc, const CpuSet& c
         DVLOG(10) << "tid: " << std::this_thread::get_id() << "; setting cpu affinity to " << affinity;
         auto rc = hwloc_set_cpubind(topology.handle(), &cpu_affinity.bitmap(), HWLOC_CPUBIND_THREAD);
         CHECK_NE(rc, -1);
-        set_current_thread_name(MRC_CONCAT_STR("[" << desc << "; " << affinity << "]"));
+        set_current_thread_name(MRC_CONCAT_STR(desc << ";" << affinity));
     }
     else
     {
         DVLOG(10) << "thread_binding is disabled; tid: " << std::this_thread::get_id()
                   << " will use the affinity of caller";
-        set_current_thread_name(MRC_CONCAT_STR("[" << desc << "; tid:" << std::this_thread::get_id() << "]"));
+        set_current_thread_name(MRC_CONCAT_STR(desc << ";tid[" << std::this_thread::get_id() << "]"));
     }
 
     // todo(ryan) - enable thread/memory binding should be a system option, not specifically a fiber_pool option

--- a/cpp/mrc/src/tests/CMakeLists.txt
+++ b/cpp/mrc/src/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(test_mrc_private
   test_resources.cpp
   test_reusable_pool.cpp
   test_runnable.cpp
+  test_service.cpp
   test_system.cpp
   test_topology.cpp
   test_ucx.cpp

--- a/cpp/mrc/src/tests/test_control_plane.cpp
+++ b/cpp/mrc/src/tests/test_control_plane.cpp
@@ -66,7 +66,7 @@ static auto make_runtime(std::function<void(Options& options)> options_lambda = 
 {
     auto resources = std::make_unique<resources::Manager>(
         system::SystemProvider(tests::make_system([&](Options& options) {
-            options.topology().user_cpuset("0-3");
+            options.topology().user_cpuset("0");
             options.topology().restrict_gpus(true);
             options.placement().resources_strategy(PlacementResources::Dedicated);
             options.placement().cpu_strategy(PlacementStrategy::PerMachine);
@@ -85,7 +85,10 @@ class TestControlPlane : public ::testing::Test
 
 TEST_F(TestControlPlane, LifeCycle)
 {
-    auto sr     = make_runtime();
+    auto sr     = make_runtime([](Options& options) {
+        options.enable_server(true);
+        options.architect_url("localhost:13337");
+    });
     auto server = std::make_unique<control_plane::Server>(sr->partition(0).resources().runnable());
 
     server->service_start();

--- a/cpp/mrc/src/tests/test_pipeline.cpp
+++ b/cpp/mrc/src/tests/test_pipeline.cpp
@@ -139,7 +139,6 @@ static void run_manager(std::unique_ptr<pipeline::IPipeline> pipeline, bool dela
         }
     });
 
-    manager->service_start();
     manager->push_updates(std::move(update));
     manager->service_await_join();
 

--- a/cpp/mrc/src/tests/test_pipeline.cpp
+++ b/cpp/mrc/src/tests/test_pipeline.cpp
@@ -111,7 +111,6 @@ static void run_custom_manager(std::unique_ptr<pipeline::IPipeline> pipeline,
         }
     });
 
-    manager->service_start();
     manager->push_updates(std::move(update));
     manager->service_await_join();
 

--- a/cpp/mrc/src/tests/test_service.cpp
+++ b/cpp/mrc/src/tests/test_service.cpp
@@ -335,6 +335,19 @@ TEST_F(TestService, MultipleJoinCalls)
     EXPECT_EQ(service.await_join_call_count(), 1);
 }
 
+TEST_F(TestService, StartWithException)
+{
+    SimpleService service;
+
+    service.set_start_callback([]() {
+        throw exceptions::MrcRuntimeError("Live Exception");
+    });
+
+    EXPECT_ANY_THROW(service.service_start());
+
+    EXPECT_EQ(service.state(), ServiceState::Completed);
+}
+
 TEST_F(TestService, LiveWithException)
 {
     SimpleService service;

--- a/cpp/mrc/src/tests/test_service.cpp
+++ b/cpp/mrc/src/tests/test_service.cpp
@@ -1,0 +1,392 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tests/common.hpp"
+
+#include "internal/service.hpp"
+
+#include "mrc/exceptions/runtime_error.hpp"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+namespace mrc {
+
+class SimpleService : public Service
+{
+  public:
+    SimpleService(bool do_call_in_destructor = true) :
+      Service("SimpleService"),
+      m_do_call_in_destructor(do_call_in_destructor)
+    {}
+
+    ~SimpleService() override
+    {
+        if (m_do_call_in_destructor)
+        {
+            Service::call_in_destructor();
+        }
+    }
+
+    size_t start_call_count() const
+    {
+        return m_start_call_count.load();
+    }
+
+    size_t stop_call_count() const
+    {
+        return m_stop_call_count.load();
+    }
+
+    size_t kill_call_count() const
+    {
+        return m_kill_call_count.load();
+    }
+
+    size_t await_live_call_count() const
+    {
+        return m_await_live_call_count.load();
+    }
+
+    size_t await_join_call_count() const
+    {
+        return m_await_join_call_count.load();
+    }
+
+    void set_start_callback(std::function<void()> callback)
+    {
+        m_start_callback = std::move(callback);
+    }
+
+    void set_stop_callback(std::function<void()> callback)
+    {
+        m_stop_callback = std::move(callback);
+    }
+
+    void set_kill_callback(std::function<void()> callback)
+    {
+        m_kill_callback = std::move(callback);
+    }
+
+    void set_await_live_callback(std::function<void()> callback)
+    {
+        m_await_live_callback = std::move(callback);
+    }
+
+    void set_await_join_callback(std::function<void()> callback)
+    {
+        m_await_join_callback = std::move(callback);
+    }
+
+  private:
+    void do_service_start() final
+    {
+        if (m_start_callback)
+        {
+            m_start_callback();
+        }
+
+        m_start_call_count++;
+    }
+
+    void do_service_stop() final
+    {
+        if (m_stop_callback)
+        {
+            m_stop_callback();
+        }
+
+        m_stop_call_count++;
+    }
+
+    void do_service_kill() final
+    {
+        if (m_kill_callback)
+        {
+            m_kill_callback();
+        }
+
+        m_kill_call_count++;
+    }
+
+    void do_service_await_live() final
+    {
+        if (m_await_live_callback)
+        {
+            m_await_live_callback();
+        }
+
+        m_await_live_call_count++;
+    }
+
+    void do_service_await_join() final
+    {
+        if (m_await_join_callback)
+        {
+            m_await_join_callback();
+        }
+
+        m_await_join_call_count++;
+    }
+
+    bool m_do_call_in_destructor{true};
+
+    std::atomic_size_t m_start_call_count{0};
+    std::atomic_size_t m_stop_call_count{0};
+    std::atomic_size_t m_kill_call_count{0};
+    std::atomic_size_t m_await_live_call_count{0};
+    std::atomic_size_t m_await_join_call_count{0};
+
+    std::function<void()> m_start_callback;
+    std::function<void()> m_stop_callback;
+    std::function<void()> m_kill_callback;
+    std::function<void()> m_await_live_callback;
+    std::function<void()> m_await_join_callback;
+};
+
+class TestService : public ::testing::Test
+{
+  protected:
+};
+
+TEST_F(TestService, LifeCycle)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    EXPECT_EQ(service.state(), ServiceState::Running);
+    EXPECT_EQ(service.start_call_count(), 1);
+
+    service.service_await_live();
+
+    EXPECT_EQ(service.await_live_call_count(), 1);
+
+    service.service_await_join();
+
+    EXPECT_EQ(service.state(), ServiceState::Completed);
+    EXPECT_EQ(service.await_join_call_count(), 1);
+
+    EXPECT_EQ(service.stop_call_count(), 0);
+    EXPECT_EQ(service.kill_call_count(), 0);
+}
+
+TEST_F(TestService, ServiceNotStarted)
+{
+    SimpleService service;
+
+    EXPECT_ANY_THROW(service.service_await_live());
+    EXPECT_ANY_THROW(service.service_stop());
+    EXPECT_ANY_THROW(service.service_kill());
+    EXPECT_ANY_THROW(service.service_await_join());
+}
+
+TEST_F(TestService, ServiceStop)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    EXPECT_EQ(service.state(), ServiceState::Running);
+
+    service.service_stop();
+
+    EXPECT_EQ(service.state(), ServiceState::Stopping);
+
+    service.service_await_join();
+
+    EXPECT_EQ(service.state(), ServiceState::Completed);
+
+    EXPECT_EQ(service.stop_call_count(), 1);
+}
+
+TEST_F(TestService, ServiceKill)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    EXPECT_EQ(service.state(), ServiceState::Running);
+
+    service.service_kill();
+
+    EXPECT_EQ(service.state(), ServiceState::Killing);
+
+    service.service_await_join();
+
+    EXPECT_EQ(service.state(), ServiceState::Completed);
+
+    EXPECT_EQ(service.kill_call_count(), 1);
+}
+
+TEST_F(TestService, ServiceStopThenKill)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    EXPECT_EQ(service.state(), ServiceState::Running);
+
+    service.service_stop();
+
+    EXPECT_EQ(service.state(), ServiceState::Stopping);
+
+    service.service_kill();
+
+    EXPECT_EQ(service.state(), ServiceState::Killing);
+
+    service.service_await_join();
+
+    EXPECT_EQ(service.state(), ServiceState::Completed);
+
+    EXPECT_EQ(service.stop_call_count(), 1);
+    EXPECT_EQ(service.kill_call_count(), 1);
+}
+
+TEST_F(TestService, ServiceKillThenStop)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    EXPECT_EQ(service.state(), ServiceState::Running);
+
+    service.service_kill();
+
+    EXPECT_EQ(service.state(), ServiceState::Killing);
+
+    service.service_stop();
+
+    EXPECT_EQ(service.state(), ServiceState::Killing);
+
+    service.service_await_join();
+
+    EXPECT_EQ(service.state(), ServiceState::Completed);
+
+    EXPECT_EQ(service.stop_call_count(), 0);
+    EXPECT_EQ(service.kill_call_count(), 1);
+}
+
+TEST_F(TestService, MultipleStartCalls)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    // Call again (should be an error)
+    EXPECT_ANY_THROW(service.service_start());
+
+    EXPECT_EQ(service.start_call_count(), 1);
+}
+
+TEST_F(TestService, MultipleStopCalls)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    // Multiple calls to stop are fine
+    service.service_stop();
+    service.service_stop();
+
+    EXPECT_EQ(service.stop_call_count(), 1);
+}
+
+TEST_F(TestService, MultipleKillCalls)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    // Multiple calls to kill are fine
+    service.service_kill();
+    service.service_kill();
+
+    EXPECT_EQ(service.kill_call_count(), 1);
+}
+
+TEST_F(TestService, MultipleJoinCalls)
+{
+    SimpleService service;
+
+    service.service_start();
+
+    service.service_await_live();
+
+    service.service_await_join();
+    service.service_await_join();
+
+    EXPECT_EQ(service.await_join_call_count(), 1);
+}
+
+TEST_F(TestService, LiveWithException)
+{
+    SimpleService service;
+
+    service.set_await_join_callback([]() {
+        throw exceptions::MrcRuntimeError("Live Exception");
+    });
+
+    service.service_start();
+
+    EXPECT_ANY_THROW(service.service_await_join());
+}
+
+TEST_F(TestService, MultipleLiveWithException)
+{
+    SimpleService service;
+
+    service.set_await_live_callback([]() {
+        throw exceptions::MrcRuntimeError("Live Exception");
+    });
+
+    service.service_start();
+
+    EXPECT_ANY_THROW(service.service_await_live());
+    EXPECT_ANY_THROW(service.service_await_live());
+}
+
+TEST_F(TestService, JoinWithException)
+{
+    SimpleService service;
+
+    service.set_await_join_callback([]() {
+        throw exceptions::MrcRuntimeError("Join Exception");
+    });
+
+    service.service_start();
+
+    EXPECT_ANY_THROW(service.service_await_join());
+}
+
+TEST_F(TestService, MultipleJoinWithException)
+{
+    SimpleService service;
+
+    service.set_await_join_callback([]() {
+        throw exceptions::MrcRuntimeError("Join Exception");
+    });
+
+    service.service_start();
+
+    EXPECT_ANY_THROW(service.service_await_join());
+    EXPECT_ANY_THROW(service.service_await_join());
+}
+
+}  // namespace mrc

--- a/cpp/mrc/tests/modules/test_segment_modules.cpp
+++ b/cpp/mrc/tests/modules/test_segment_modules.cpp
@@ -118,7 +118,7 @@ TEST_F(TestSegmentModules, ModuleInitializationTest)
 
     Executor executor(options);
     executor.register_pipeline(std::move(m_pipeline));
-    executor.stop();
+    executor.start();
     executor.join();
 }
 

--- a/cpp/mrc/tests/modules/test_stream_buffer_modules.cpp
+++ b/cpp/mrc/tests/modules/test_stream_buffer_modules.cpp
@@ -70,7 +70,7 @@ TEST_F(TestStreamBufferModule, InitailizationTest)
 
     Executor executor(options);
     executor.register_pipeline(std::move(m_pipeline));
-    executor.stop();
+    executor.start();
     executor.join();
 }
 


### PR DESCRIPTION
## Description
This PR incorporates several changes from the MNMG work into the current code base. The main goal of this PR was to eliminate the unnecessary warnings generated during tests. Such as:
```
E20230905 22:54:41.207543  6472 service.cpp:136] mrc::service: service was not joined before being destructed; issuing join
```

This PR includes the following improvements (all taken from MNMG):

- Improved lifetime handling of `Service` classes
- Required name for all `Service` classes to help with debugging
- Improved thread naming to fit within the 15 character limit
- Added service tests file for ensuring exceptions and state is properly handled

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
