### PR TITLE
Fix EdgeHolder from incorrectly reporting an active connection

### DIFF
--- a/cpp/mrc/include/mrc/edge/edge_holder.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_holder.hpp
@@ -152,7 +152,6 @@ class EdgeHolder
 
     void release_edge_connection()
     {
-        m_owned_edge_lifetime.reset();
         m_connected_edge.reset();
     }
 

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -58,7 +58,7 @@ using namespace std::chrono_literals;
 
 TEST_CLASS(Edges);
 
-using TestEdgesDeathTest = TestEdges;  // NOLINT(readability-identifier-naming)p
+using TestEdgesDeathTest = TestEdges;  // NOLINT(readability-identifier-naming)
 
 namespace mrc::node {
 

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -1011,14 +1011,23 @@ class TestEdgeHolder : public edge::EdgeHolder<T>
     {
         this->release_edge_connection();
     }
+
+    void call_init_owned_edge(std::shared_ptr<edge::Edge<T>> edge)
+    {
+        this->init_owned_edge(std::move(edge));
+    }
 };
 
 TEST_F(TestEdges, EdgeHolderIsConnected)
 {
     TestEdgeHolder<int> edge_holder;
-
+    auto edge = std::make_shared<edge::Edge<int>>();
     EXPECT_FALSE(edge_holder.has_active_connection());
+
+    edge_holder.call_init_owned_edge(edge);
+    EXPECT_FALSE(edge_holder.has_active_connection());
+
     edge_holder.call_release_edge_connection();
-    EXPECT_TRUE(edge_holder.has_active_connection());
+    EXPECT_FALSE(edge_holder.has_active_connection());
 }
 }  // namespace mrc

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -23,6 +23,7 @@
 #include "mrc/edge/edge_channel.hpp"
 #include "mrc/edge/edge_readable.hpp"
 #include "mrc/edge/edge_writable.hpp"
+#include "mrc/edge/forward.hpp"
 #include "mrc/node/generic_source.hpp"
 #include "mrc/node/operators/broadcast.hpp"
 #include "mrc/node/operators/combine_latest.hpp"
@@ -57,7 +58,7 @@ using namespace std::chrono_literals;
 
 TEST_CLASS(Edges);
 
-using TestEdgesDeathTest = TestEdges;  // NOLINT(readability-identifier-naming)
+using TestEdgesDeathTest = TestEdges;  // NOLINT(readability-identifier-naming)p
 
 namespace mrc::node {
 
@@ -995,5 +996,29 @@ TEST_F(TestEdges, EdgeTapWithSpliceRxComponent)
     sink->run();
 
     EXPECT_TRUE(node->stream_fn_called);
+}
+
+template <typename T>
+class TestEdgeHolder : public edge::EdgeHolder<T>
+{
+  public:
+    bool has_active_connection() const
+    {
+        return this->check_active_connection(false);
+    }
+
+    void call_release_edge_connection()
+    {
+        this->release_edge_connection();
+    }
+};
+
+TEST_F(TestEdges, EdgeHolderIsConnected)
+{
+    TestEdgeHolder<int> edge_holder;
+
+    EXPECT_FALSE(edge_holder.has_active_connection());
+    edge_holder.call_release_edge_connection();
+    EXPECT_TRUE(edge_holder.has_active_connection());
 }
 }  // namespace mrc

--- a/cpp/mrc/tests/test_edges.cpp
+++ b/cpp/mrc/tests/test_edges.cpp
@@ -19,11 +19,12 @@
 
 #include "mrc/channel/buffered_channel.hpp"  // IWYU pragma: keep
 #include "mrc/channel/forward.hpp"
+#include "mrc/edge/edge.hpp"  // for Edge
 #include "mrc/edge/edge_builder.hpp"
 #include "mrc/edge/edge_channel.hpp"
+#include "mrc/edge/edge_holder.hpp"  // for EdgeHolder
 #include "mrc/edge/edge_readable.hpp"
 #include "mrc/edge/edge_writable.hpp"
-#include "mrc/edge/forward.hpp"
 #include "mrc/node/generic_source.hpp"
 #include "mrc/node/operators/broadcast.hpp"
 #include "mrc/node/operators/combine_latest.hpp"
@@ -41,7 +42,6 @@
 #include <rxcpp/rx.hpp>  // for observable_member
 
 #include <functional>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <stdexcept>


### PR DESCRIPTION
## Description
* Prevents `check_active_connection` from mistakenly returning true for a holder where `init_owned_edge` has been called but neither the `init_connected_edge method` or the `add_connector` method have not been called.

Relates to issue #360

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
