### PR TITLE
Update boost versions to match version used in dev env

### DIFF
--- a/ci/conda/recipes/libmrc/conda_build_config.yaml
+++ b/ci/conda/recipes/libmrc/conda_build_config.yaml
@@ -71,9 +71,9 @@ zip_keys:
 # The following mimic what is available in the pinning feedstock:
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 boost:
-  - 1.74.0
+  - 1.82
 boost_cpp:
-  - 1.74.0
+  - 1.82
 gflags:
   - 2.2
 glog:


### PR DESCRIPTION
## Description
PR #391 updated the version of boost, but I forgot to update the version in the package's yaml.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
