### PR TITLE
Adding more coroutine components to support async generators and task containers

### DIFF
--- a/cpp/mrc/CMakeLists.txt
+++ b/cpp/mrc/CMakeLists.txt
@@ -115,7 +115,9 @@ add_library(libmrc
   src/public/core/logging.cpp
   src/public/core/thread.cpp
   src/public/coroutines/event.cpp
+  src/public/coroutines/scheduler.cpp
   src/public/coroutines/sync_wait.cpp
+  src/public/coroutines/task_container.cpp
   src/public/coroutines/thread_local_context.cpp
   src/public/coroutines/thread_pool.cpp
   src/public/cuda/device_guard.cpp

--- a/cpp/mrc/include/mrc/coroutines/async_generator.hpp
+++ b/cpp/mrc/include/mrc/coroutines/async_generator.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/include/mrc/coroutines/async_generator.hpp
+++ b/cpp/mrc/include/mrc/coroutines/async_generator.hpp
@@ -1,0 +1,399 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Original Source: https://github.com/lewissbaker/cppcoro
+ * Original License: MIT; included below
+ */
+
+// Copyright 2017 Lewis Baker
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "mrc/utils/macros.hpp"
+
+#include <glog/logging.h>
+
+#include <concepts>
+#include <coroutine>
+#include <exception>
+#include <type_traits>
+
+namespace mrc::coroutines {
+
+template <typename T>
+class AsyncGenerator;
+
+namespace detail {
+
+template <typename T>
+class AsyncGeneratorIterator;
+class AsyncGeneratorYieldOperation;
+class AsyncGeneratorAdvanceOperation;
+
+class AsyncGeneratorPromiseBase
+{
+  public:
+    AsyncGeneratorPromiseBase() noexcept : m_exception(nullptr) {}
+
+    DELETE_COPYABILITY(AsyncGeneratorPromiseBase)
+
+    constexpr static std::suspend_always initial_suspend() noexcept
+    {
+        return {};
+    }
+
+    AsyncGeneratorYieldOperation final_suspend() noexcept;
+
+    void unhandled_exception() noexcept
+    {
+        m_exception = std::current_exception();
+    }
+
+    auto return_void() noexcept -> void {}
+
+    auto finished() const noexcept -> bool
+    {
+        return m_value == nullptr;
+    }
+
+    auto rethrow_on_unhandled_exception() -> void
+    {
+        if (m_exception)
+        {
+            std::rethrow_exception(m_exception);
+        }
+    }
+
+  protected:
+    AsyncGeneratorYieldOperation internal_yield_value() noexcept;
+    void* m_value{nullptr};
+
+  private:
+    std::exception_ptr m_exception;
+    std::coroutine_handle<> m_consumer;
+
+    friend class AsyncGeneratorYieldOperation;
+    friend class AsyncGeneratorAdvanceOperation;
+};
+
+class AsyncGeneratorYieldOperation final
+{
+  public:
+    AsyncGeneratorYieldOperation(std::coroutine_handle<> consumer) noexcept : m_consumer(consumer) {}
+
+    constexpr static bool await_ready() noexcept
+    {
+        return false;
+    }
+
+    std::coroutine_handle<> await_suspend([[maybe_unused]] std::coroutine_handle<> producer) const noexcept
+    {
+        return m_consumer;
+    }
+
+    constexpr static void await_resume() noexcept {}
+
+  private:
+    std::coroutine_handle<> m_consumer;
+};
+
+inline AsyncGeneratorYieldOperation AsyncGeneratorPromiseBase::final_suspend() noexcept
+{
+    m_value = nullptr;
+    return internal_yield_value();
+}
+
+inline AsyncGeneratorYieldOperation AsyncGeneratorPromiseBase::internal_yield_value() noexcept
+{
+    return AsyncGeneratorYieldOperation{m_consumer};
+}
+
+class AsyncGeneratorAdvanceOperation
+{
+  protected:
+    AsyncGeneratorAdvanceOperation(std::nullptr_t) noexcept : m_promise(nullptr), m_producer(nullptr) {}
+
+    AsyncGeneratorAdvanceOperation(AsyncGeneratorPromiseBase& promise, std::coroutine_handle<> producer) noexcept :
+      m_promise(std::addressof(promise)),
+      m_producer(producer)
+    {}
+
+  public:
+    constexpr static bool await_ready() noexcept
+    {
+        return false;
+    }
+
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> consumer) noexcept
+    {
+        m_promise->m_consumer = consumer;
+        return m_producer;
+    }
+
+  protected:
+    AsyncGeneratorPromiseBase* m_promise;
+    std::coroutine_handle<> m_producer;
+};
+
+template <typename T>
+class AsyncGeneratorPromise final : public AsyncGeneratorPromiseBase
+{
+    using value_t     = std::remove_reference_t<T>;
+    using reference_t = std::conditional_t<std::is_reference_v<T>, T, T&>;
+    using pointer_t   = value_t*;
+
+  public:
+    AsyncGeneratorPromise() noexcept = default;
+
+    AsyncGenerator<T> get_return_object() noexcept;
+
+    template <typename U = T, std::enable_if_t<!std::is_rvalue_reference<U>::value, int> = 0>
+    auto yield_value(value_t& value) noexcept -> AsyncGeneratorYieldOperation
+    {
+        m_value = std::addressof(value);
+        return internal_yield_value();
+    }
+
+    auto yield_value(value_t&& value) noexcept -> AsyncGeneratorYieldOperation
+    {
+        m_value = std::addressof(value);
+        return internal_yield_value();
+    }
+
+    auto value() const noexcept -> reference_t
+    {
+        return *static_cast<pointer_t>(m_value);
+    }
+};
+
+template <typename T>
+class AsyncGeneratorIncrementOperation final : public AsyncGeneratorAdvanceOperation
+{
+  public:
+    AsyncGeneratorIncrementOperation(AsyncGeneratorIterator<T>& iterator) noexcept :
+      AsyncGeneratorAdvanceOperation(iterator.m_coroutine.promise(), iterator.m_coroutine),
+      m_iterator(iterator)
+    {}
+
+    AsyncGeneratorIterator<T>& await_resume();
+
+  private:
+    AsyncGeneratorIterator<T>& m_iterator;
+};
+
+struct AsyncGeneratorSentinel
+{};
+
+template <typename T>
+class AsyncGeneratorIterator final
+{
+    using promise_t = AsyncGeneratorPromise<T>;
+    using handle_t  = std::coroutine_handle<promise_t>;
+
+  public:
+    using iterator_category = std::input_iterator_tag;  // NOLINT
+    // Not sure what type should be used for difference_type as we don't
+    // allow calculating difference between two iterators.
+    using difference_t = std::ptrdiff_t;
+    using value_t      = std::remove_reference_t<T>;
+    using reference    = std::add_lvalue_reference_t<T>;  // NOLINT
+    using pointer      = std::add_pointer_t<value_t>;     // NOLINT
+
+    AsyncGeneratorIterator(std::nullptr_t) noexcept : m_coroutine(nullptr) {}
+
+    AsyncGeneratorIterator(handle_t coroutine) noexcept : m_coroutine(coroutine) {}
+
+    AsyncGeneratorIncrementOperation<T> operator++() noexcept
+    {
+        return AsyncGeneratorIncrementOperation<T>{*this};
+    }
+
+    reference operator*() const noexcept
+    {
+        return m_coroutine.promise().value();
+    }
+
+    bool operator==(const AsyncGeneratorIterator& other) const noexcept
+    {
+        return m_coroutine == other.m_coroutine;
+    }
+
+    bool operator!=(const AsyncGeneratorIterator& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+    operator bool() const noexcept
+    {
+        return m_coroutine && !m_coroutine.promise().finished();
+    }
+
+  private:
+    friend class AsyncGeneratorIncrementOperation<T>;
+
+    handle_t m_coroutine;
+};
+
+template <typename T>
+inline AsyncGeneratorIterator<T>& AsyncGeneratorIncrementOperation<T>::await_resume()
+{
+    if (m_promise->finished())
+    {
+        // Update iterator to end()
+        m_iterator = AsyncGeneratorIterator<T>{nullptr};
+        m_promise->rethrow_on_unhandled_exception();
+    }
+
+    return m_iterator;
+}
+
+template <typename T>
+class AsyncGeneratorBeginOperation final : public AsyncGeneratorAdvanceOperation
+{
+    using promise_t = AsyncGeneratorPromise<T>;
+    using handle_t  = std::coroutine_handle<promise_t>;
+
+  public:
+    AsyncGeneratorBeginOperation(std::nullptr_t) noexcept : AsyncGeneratorAdvanceOperation(nullptr) {}
+
+    AsyncGeneratorBeginOperation(handle_t producer) noexcept :
+      AsyncGeneratorAdvanceOperation(producer.promise(), producer)
+    {}
+
+    bool await_ready() const noexcept
+    {
+        return m_promise == nullptr || AsyncGeneratorAdvanceOperation::await_ready();
+    }
+
+    AsyncGeneratorIterator<T> await_resume()
+    {
+        if (m_promise == nullptr)
+        {
+            // Called begin() on the empty generator.
+            return AsyncGeneratorIterator<T>{nullptr};
+        }
+
+        if (m_promise->finished())
+        {
+            // Completed without yielding any values.
+            m_promise->rethrow_on_unhandled_exception();
+            return AsyncGeneratorIterator<T>{nullptr};
+        }
+
+        return AsyncGeneratorIterator<T>{handle_t::from_promise(*static_cast<promise_t*>(m_promise))};
+    }
+};
+
+}  // namespace detail
+
+template <typename T>
+class [[nodiscard]] AsyncGenerator
+{
+  public:
+    // There must be a type called `promise_type` for coroutines to work. Skil linting
+    using promise_type = detail::AsyncGeneratorPromise<T>;   // NOLINT(readability-identifier-naming)
+    using iterator     = detail::AsyncGeneratorIterator<T>;  // NOLINT(readability-identifier-naming)
+
+    AsyncGenerator() noexcept : m_coroutine(nullptr) {}
+
+    explicit AsyncGenerator(promise_type& promise) noexcept :
+      m_coroutine(std::coroutine_handle<promise_type>::from_promise(promise))
+    {}
+
+    AsyncGenerator(AsyncGenerator&& other) noexcept : m_coroutine(other.m_coroutine)
+    {
+        other.m_coroutine = nullptr;
+    }
+
+    ~AsyncGenerator()
+    {
+        if (m_coroutine)
+        {
+            m_coroutine.destroy();
+        }
+    }
+
+    AsyncGenerator& operator=(AsyncGenerator&& other) noexcept
+    {
+        AsyncGenerator temp(std::move(other));
+        swap(temp);
+        return *this;
+    }
+
+    AsyncGenerator(const AsyncGenerator&)            = delete;
+    AsyncGenerator& operator=(const AsyncGenerator&) = delete;
+
+    auto begin() noexcept
+    {
+        if (!m_coroutine)
+        {
+            return detail::AsyncGeneratorBeginOperation<T>{nullptr};
+        }
+
+        return detail::AsyncGeneratorBeginOperation<T>{m_coroutine};
+    }
+
+    auto end() noexcept
+    {
+        return iterator{nullptr};
+    }
+
+    void swap(AsyncGenerator& other) noexcept
+    {
+        using std::swap;
+        swap(m_coroutine, other.m_coroutine);
+    }
+
+  private:
+    std::coroutine_handle<promise_type> m_coroutine;
+};
+
+template <typename T>
+void swap(AsyncGenerator<T>& a, AsyncGenerator<T>& b) noexcept
+{
+    a.swap(b);
+}
+
+namespace detail {
+template <typename T>
+AsyncGenerator<T> AsyncGeneratorPromise<T>::get_return_object() noexcept
+{
+    return AsyncGenerator<T>{*this};
+}
+
+}  // namespace detail
+
+}  // namespace mrc::coroutines

--- a/cpp/mrc/include/mrc/coroutines/closable_ring_buffer.hpp
+++ b/cpp/mrc/include/mrc/coroutines/closable_ring_buffer.hpp
@@ -1,0 +1,703 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Original Source: https://github.com/jbaldwin/libcoro
+ * Original License: Apache License, Version 2.0; included below
+ */
+
+/**
+ * Copyright 2021 Josh Baldwin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mrc/core/expected.hpp"
+#include "mrc/coroutines/schedule_policy.hpp"
+#include "mrc/coroutines/thread_local_context.hpp"
+#include "mrc/coroutines/thread_pool.hpp"
+
+#include <glog/logging.h>
+
+#include <atomic>
+#include <coroutine>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace mrc::coroutines {
+
+enum class RingBufferOpStatus
+{
+    Success,
+    Stopped,
+};
+
+/**
+ * @tparam ElementT The type of element the ring buffer will store.  Note that this type should be
+ *         cheap to move if possible as it is moved into and out of the buffer upon write and
+ *         read operations.
+ */
+template <typename ElementT>
+class ClosableRingBuffer
+{
+    using mutex_type = std::mutex;
+
+  public:
+    struct Options
+    {
+        // capacity of ring buffer
+        std::size_t capacity{8};
+
+        // when there is an awaiting reader, the active execution context of the next writer will resume the awaiting
+        // reader, the schedule_policy_t dictates how that is accomplished.
+        SchedulePolicy reader_policy{SchedulePolicy::Reschedule};
+
+        // when there is an awaiting writer, the active execution context of the next reader will resume the awaiting
+        // writer, the producder_policy_t dictates how that is accomplished.
+        SchedulePolicy writer_policy{SchedulePolicy::Reschedule};
+
+        // when there is an awaiting writer, the active execution context of the next reader will resume the awaiting
+        // writer, the producder_policy_t dictates how that is accomplished.
+        SchedulePolicy completed_policy{SchedulePolicy::Reschedule};
+    };
+
+    /**
+     * @throws std::runtime_error If `num_elements` == 0.
+     */
+    explicit ClosableRingBuffer(Options opts = {}) :
+      m_elements(opts.capacity),  // elements needs to be extended from just holding ElementT to include a TraceContext
+      m_num_elements(opts.capacity),
+      m_writer_policy(opts.writer_policy),
+      m_reader_policy(opts.reader_policy),
+      m_completed_policy(opts.completed_policy)
+    {
+        if (m_num_elements == 0)
+        {
+            throw std::runtime_error{"num_elements cannot be zero"};
+        }
+    }
+
+    ~ClosableRingBuffer()
+    {
+        // Wake up anyone still using the ring buffer.
+        notify_waiters();
+    }
+
+    ClosableRingBuffer(const ClosableRingBuffer<ElementT>&) = delete;
+    ClosableRingBuffer(ClosableRingBuffer<ElementT>&&)      = delete;
+
+    auto operator=(const ClosableRingBuffer<ElementT>&) noexcept -> ClosableRingBuffer<ElementT>& = delete;
+    auto operator=(ClosableRingBuffer<ElementT>&&) noexcept -> ClosableRingBuffer<ElementT>&      = delete;
+
+    struct Operation
+    {
+        virtual void resume() = 0;
+    };
+
+    struct WriteOperation : ThreadLocalContext, Operation
+    {
+        WriteOperation(ClosableRingBuffer<ElementT>& rb, ElementT e) :
+          m_rb(rb),
+          m_e(std::move(e)),
+          m_policy(m_rb.m_writer_policy)
+        {}
+
+        auto await_ready() noexcept -> bool
+        {
+            // return immediate if the buffer is closed
+            if (m_rb.m_stopped.load(std::memory_order::acquire))
+            {
+                m_stopped = true;
+                return true;
+            }
+
+            // start a span to time the write - this would include time suspended if the buffer is full
+            // m_write_span->AddEvent("start_on", {{"thead.id", mrc::this_thread::get_id()}});
+
+            // the lock is owned by the operation, not scoped to the await_ready function
+            m_lock = std::unique_lock(m_rb.m_mutex);
+            return m_rb.try_write_locked(m_lock, m_e);
+        }
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+        {
+            // m_lock was acquired as part of await_ready; await_suspend is responsible for releasing the lock
+            auto lock = std::move(m_lock);  // use raii
+
+            ThreadLocalContext::suspend_thread_local_context();
+
+            m_awaiting_coroutine = awaiting_coroutine;
+            m_next               = m_rb.m_write_waiters;
+            m_rb.m_write_waiters = this;
+            return true;
+        }
+
+        /**
+         * @return write_result
+         */
+        auto await_resume() -> RingBufferOpStatus
+        {
+            ThreadLocalContext::resume_thread_local_context();
+            return (!m_stopped ? RingBufferOpStatus::Success : RingBufferOpStatus::Stopped);
+        }
+
+        WriteOperation& use_scheduling_policy(SchedulePolicy policy) &
+        {
+            m_policy = policy;
+            return *this;
+        }
+
+        WriteOperation use_scheduling_policy(SchedulePolicy policy) &&
+        {
+            m_policy = policy;
+            return std::move(*this);
+        }
+
+        WriteOperation& resume_immediately() &
+        {
+            m_policy = SchedulePolicy::Immediate;
+            return *this;
+        }
+
+        WriteOperation resume_immediately() &&
+        {
+            m_policy = SchedulePolicy::Immediate;
+            return std::move(*this);
+        }
+
+        WriteOperation& resume_on(ThreadPool* thread_pool) &
+        {
+            m_policy = SchedulePolicy::Reschedule;
+            set_resume_on_thread_pool(thread_pool);
+            return *this;
+        }
+
+        WriteOperation resume_on(ThreadPool* thread_pool) &&
+        {
+            m_policy = SchedulePolicy::Reschedule;
+            set_resume_on_thread_pool(thread_pool);
+            return std::move(*this);
+        }
+
+      private:
+        friend ClosableRingBuffer;
+
+        void resume()
+        {
+            if (m_policy == SchedulePolicy::Immediate)
+            {
+                set_resume_on_thread_pool(nullptr);
+            }
+            resume_coroutine(m_awaiting_coroutine);
+        }
+
+        /// The lock is acquired in await_ready; if ready it is release; otherwise, await_suspend should release it
+        std::unique_lock<mutex_type> m_lock;
+        /// The ring buffer the element is being written into.
+        ClosableRingBuffer<ElementT>& m_rb;
+        /// If the operation needs to suspend, the coroutine to resume when the element can be written.
+        std::coroutine_handle<> m_awaiting_coroutine;
+        /// Linked list of write operations that are awaiting to write their element.
+        WriteOperation* m_next{nullptr};
+        /// The element this write operation is producing into the ring buffer.
+        ElementT m_e;
+        /// Was the operation stopped?
+        bool m_stopped{false};
+        /// Scheduling Policy - default provided by the ClosableRingBuffer, but can be overrided owner of the Awaiter
+        SchedulePolicy m_policy;
+        /// Span to measure the duration the writer spent writting data
+        // trace::Handle<trace::Span> m_write_span{nullptr};
+    };
+
+    struct ReadOperation : ThreadLocalContext, Operation
+    {
+        explicit ReadOperation(ClosableRingBuffer<ElementT>& rb) : m_rb(rb), m_policy(m_rb.m_reader_policy) {}
+
+        auto await_ready() noexcept -> bool
+        {
+            // the lock is owned by the operation, not scoped to the await_ready function
+            m_lock = std::unique_lock(m_rb.m_mutex);
+            // m_read_span->AddEvent("start_on", {{"thead.id", mrc::this_thread::get_id()}});
+            return m_rb.try_read_locked(m_lock, this);
+        }
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+        {
+            // m_lock was acquired as part of await_ready; await_suspend is responsible for releasing the lock
+            auto lock = std::move(m_lock);
+
+            // the buffer is empty; don't suspend if the stop signal has been set.
+            if (m_rb.m_stopped.load(std::memory_order::acquire))
+            {
+                m_stopped = true;
+                return false;
+            }
+
+            // m_read_span->AddEvent("buffer_empty");
+            ThreadLocalContext::suspend_thread_local_context();
+
+            m_awaiting_coroutine = awaiting_coroutine;
+            m_next               = m_rb.m_read_waiters;
+            m_rb.m_read_waiters  = this;
+            return true;
+        }
+
+        /**
+         * @return The consumed element or std::nullopt if the read has failed.
+         */
+        auto await_resume() -> mrc::expected<ElementT, RingBufferOpStatus>
+        {
+            ThreadLocalContext::resume_thread_local_context();
+
+            if (m_stopped)
+            {
+                return mrc::unexpected<RingBufferOpStatus>(RingBufferOpStatus::Stopped);
+            }
+
+            return std::move(m_e);
+        }
+
+        ReadOperation& use_scheduling_policy(SchedulePolicy policy)
+        {
+            m_policy = policy;
+            return *this;
+        }
+
+        ReadOperation& resume_immediately()
+        {
+            m_policy = SchedulePolicy::Immediate;
+            return *this;
+        }
+
+        ReadOperation& resume_on(ThreadPool* thread_pool)
+        {
+            m_policy = SchedulePolicy::Reschedule;
+            set_resume_on_thread_pool(thread_pool);
+            return *this;
+        }
+
+      private:
+        friend ClosableRingBuffer;
+
+        void resume()
+        {
+            if (m_policy == SchedulePolicy::Immediate)
+            {
+                set_resume_on_thread_pool(nullptr);
+            }
+            resume_coroutine(m_awaiting_coroutine);
+        }
+
+        /// The lock is acquired in await_ready; if ready it is release; otherwise, await_suspend should release it
+        std::unique_lock<mutex_type> m_lock;
+        /// The ring buffer to read an element from.
+        ClosableRingBuffer<ElementT>& m_rb;
+        /// If the operation needs to suspend, the coroutine to resume when the element can be consumed.
+        std::coroutine_handle<> m_awaiting_coroutine;
+        /// Linked list of read operations that are awaiting to read an element.
+        ReadOperation* m_next{nullptr};
+        /// The element this read operation will read.
+        ElementT m_e;
+        /// Was the operation stopped?
+        bool m_stopped{false};
+        /// Scheduling Policy - default provided by the ClosableRingBuffer, but can be overrided owner of the Awaiter
+        SchedulePolicy m_policy;
+        /// Span measure time awaiting on reading data
+        // trace::Handle<trace::Span> m_read_span;
+    };
+
+    struct CompletedOperation : ThreadLocalContext, Operation
+    {
+        explicit CompletedOperation(ClosableRingBuffer<ElementT>& rb) : m_rb(rb), m_policy(m_rb.m_completed_policy) {}
+
+        auto await_ready() noexcept -> bool
+        {
+            // the lock is owned by the operation, not scoped to the await_ready function
+            m_lock = std::unique_lock(m_rb.m_mutex);
+            // m_read_span->AddEvent("start_on", {{"thead.id", mrc::this_thread::get_id()}});
+            return m_rb.try_completed_locked(m_lock, this);
+        }
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+        {
+            // m_lock was acquired as part of await_ready; await_suspend is responsible for releasing the lock
+            auto lock = std::move(m_lock);
+
+            // m_read_span->AddEvent("buffer_empty");
+            ThreadLocalContext::suspend_thread_local_context();
+
+            m_awaiting_coroutine     = awaiting_coroutine;
+            m_next                   = m_rb.m_completed_waiters;
+            m_rb.m_completed_waiters = this;
+            return true;
+        }
+
+        /**
+         * @return The consumed element or std::nullopt if the read has failed.
+         */
+        auto await_resume()
+        {
+            ThreadLocalContext::resume_thread_local_context();
+        }
+
+        ReadOperation& use_scheduling_policy(SchedulePolicy policy)
+        {
+            m_policy = policy;
+            return *this;
+        }
+
+        ReadOperation& resume_immediately()
+        {
+            m_policy = SchedulePolicy::Immediate;
+            return *this;
+        }
+
+        ReadOperation& resume_on(ThreadPool* thread_pool)
+        {
+            m_policy = SchedulePolicy::Reschedule;
+            set_resume_on_thread_pool(thread_pool);
+            return *this;
+        }
+
+      private:
+        friend ClosableRingBuffer;
+
+        void resume()
+        {
+            if (m_policy == SchedulePolicy::Immediate)
+            {
+                set_resume_on_thread_pool(nullptr);
+            }
+            resume_coroutine(m_awaiting_coroutine);
+        }
+
+        /// The lock is acquired in await_ready; if ready it is release; otherwise, await_suspend should release it
+        std::unique_lock<mutex_type> m_lock;
+        /// The ring buffer to read an element from.
+        ClosableRingBuffer<ElementT>& m_rb;
+        /// If the operation needs to suspend, the coroutine to resume when the element can be consumed.
+        std::coroutine_handle<> m_awaiting_coroutine;
+        /// Linked list of read operations that are awaiting to read an element.
+        CompletedOperation* m_next{nullptr};
+        /// Was the operation stopped?
+        bool m_stopped{false};
+        /// Scheduling Policy - default provided by the ClosableRingBuffer, but can be overrided owner of the Awaiter
+        SchedulePolicy m_policy;
+        /// Span measure time awaiting on reading data
+        // trace::Handle<trace::Span> m_read_span;
+    };
+
+    /**
+     * Produces the given element into the ring buffer.  This operation will suspend until a slot
+     * in the ring buffer becomes available.
+     * @param e The element to write.
+     */
+    [[nodiscard]] auto write(ElementT e) -> WriteOperation
+    {
+        return WriteOperation{*this, std::move(e)};
+    }
+
+    /**
+     * Consumes an element from the ring buffer.  This operation will suspend until an element in
+     * the ring buffer becomes available.
+     */
+    [[nodiscard]] auto read() -> ReadOperation
+    {
+        return ReadOperation{*this};
+    }
+
+    /**
+     * Blocks until `close()` has been called and all elements have been returned
+     */
+    [[nodiscard]] auto completed() -> CompletedOperation
+    {
+        return CompletedOperation{*this};
+    }
+
+    void close()
+    {
+        // if there are awaiting readers, then we must wait them up and signal that the buffer is closed;
+        // otherwise, mark the buffer as closed and fail all new writes immediately. readers should be allowed
+        // to keep reading until the buffer is empty. when the buffer is empty, readers will fail to suspend and exit
+        // with a stopped status
+
+        // Only wake up waiters once.
+        if (m_stopped.load(std::memory_order::acquire))
+        {
+            return;
+        }
+
+        std::unique_lock lk{m_mutex};
+        m_stopped.exchange(true, std::memory_order::release);
+
+        // the buffer is empty and no more items will be added
+        if (m_used == 0)
+        {
+            // there should be no awaiting writers
+            CHECK(m_write_waiters == nullptr);
+
+            // signal all awaiting readers that the buffer is stopped
+            while (m_read_waiters != nullptr)
+            {
+                auto* to_resume      = m_read_waiters;
+                to_resume->m_stopped = true;
+                m_read_waiters       = m_read_waiters->m_next;
+
+                lk.unlock();
+                to_resume->resume();
+                lk.lock();
+            }
+
+            // signal all awaiting completed that the buffer is completed
+            while (m_completed_waiters != nullptr)
+            {
+                auto* to_resume      = m_completed_waiters;
+                to_resume->m_stopped = true;
+                m_completed_waiters  = m_completed_waiters->m_next;
+
+                lk.unlock();
+                to_resume->resume();
+                lk.lock();
+            }
+        }
+    }
+
+    bool is_closed() const noexcept
+    {
+        return m_stopped.load(std::memory_order::acquire);
+    }
+
+    /**
+     * @return The current number of elements contained in the ring buffer.
+     */
+    auto size() const -> size_t
+    {
+        std::atomic_thread_fence(std::memory_order::acquire);
+        return m_used;
+    }
+
+    /**
+     * @return True if the ring buffer contains zero elements.
+     */
+    auto empty() const -> bool
+    {
+        return size() == 0;
+    }
+
+    /**
+     * Wakes up all currently awaiting writers and readers.  Their await_resume() function
+     * will return an expected read result that the ring buffer has stopped.
+     */
+    auto notify_waiters() -> void
+    {
+        // Only wake up waiters once.
+        if (m_stopped.load(std::memory_order::acquire))
+        {
+            return;
+        }
+
+        std::unique_lock lk{m_mutex};
+        m_stopped.exchange(true, std::memory_order::release);
+
+        while (m_write_waiters != nullptr)
+        {
+            auto* to_resume      = m_write_waiters;
+            to_resume->m_stopped = true;
+            m_write_waiters      = m_write_waiters->m_next;
+
+            lk.unlock();
+            to_resume->resume();
+            lk.lock();
+        }
+
+        while (m_read_waiters != nullptr)
+        {
+            auto* to_resume      = m_read_waiters;
+            to_resume->m_stopped = true;
+            m_read_waiters       = m_read_waiters->m_next;
+
+            lk.unlock();
+            to_resume->resume();
+            lk.lock();
+        }
+
+        while (m_completed_waiters != nullptr)
+        {
+            auto* to_resume      = m_completed_waiters;
+            to_resume->m_stopped = true;
+            m_completed_waiters  = m_completed_waiters->m_next;
+
+            lk.unlock();
+            to_resume->resume();
+            lk.lock();
+        }
+    }
+
+  private:
+    friend WriteOperation;
+    friend ReadOperation;
+    friend CompletedOperation;
+
+    mutex_type m_mutex{};
+
+    std::vector<ElementT> m_elements;
+    const std::size_t m_num_elements;
+    const SchedulePolicy m_writer_policy;
+    const SchedulePolicy m_reader_policy;
+    const SchedulePolicy m_completed_policy;
+
+    /// The current front pointer to an open slot if not full.
+    size_t m_front{0};
+    /// The current back pointer to the oldest item in the buffer if not empty.
+    size_t m_back{0};
+    /// The number of items in the ring buffer.
+    size_t m_used{0};
+
+    /// The LIFO list of write waiters - single writers will have order perserved
+    //  Note: if there are multiple writers order can not be guaranteed, so no need for FIFO
+    WriteOperation* m_write_waiters{nullptr};
+    /// The LIFO list of read watier.
+    ReadOperation* m_read_waiters{nullptr};
+    /// The LIFO list of completed watier.
+    CompletedOperation* m_completed_waiters{nullptr};
+
+    std::atomic<bool> m_stopped{false};
+
+    auto try_write_locked(std::unique_lock<mutex_type>& lk, ElementT& e) -> bool
+    {
+        if (m_used == m_num_elements)
+        {
+            DCHECK(m_read_waiters == nullptr);
+            return false;
+        }
+
+        // We will be able to write an element into the buffer.
+        m_elements[m_front] = std::move(e);
+        m_front             = (m_front + 1) % m_num_elements;
+        ++m_used;
+
+        ReadOperation* to_resume = nullptr;
+
+        if (m_read_waiters != nullptr)
+        {
+            to_resume      = m_read_waiters;
+            m_read_waiters = m_read_waiters->m_next;
+
+            // Since the read operation suspended it needs to be provided an element to read.
+            to_resume->m_e = std::move(m_elements[m_back]);
+            m_back         = (m_back + 1) % m_num_elements;
+            --m_used;  // And we just consumed up another item.
+        }
+
+        // After this point we will no longer be checking state objects on the buffer
+        lk.unlock();
+
+        if (to_resume != nullptr)
+        {
+            to_resume->resume();
+        }
+
+        return true;
+    }
+
+    auto try_read_locked(std::unique_lock<mutex_type>& lk, ReadOperation* op) -> bool
+    {
+        if (m_used == 0)
+        {
+            return false;
+        }
+
+        // We will be successful in reading an element from the buffer.
+        op->m_e = std::move(m_elements[m_back]);
+        m_back  = (m_back + 1) % m_num_elements;
+        --m_used;
+
+        WriteOperation* writer_to_resume = nullptr;
+
+        if (m_write_waiters != nullptr)
+        {
+            writer_to_resume = m_write_waiters;
+            m_write_waiters  = m_write_waiters->m_next;
+
+            // Since the write operation suspended it needs to be provided a slot to place its element.
+            m_elements[m_front] = std::move(writer_to_resume->m_e);
+            m_front             = (m_front + 1) % m_num_elements;
+            ++m_used;  // And we just written another item.
+        }
+
+        CompletedOperation* completed_waiters = nullptr;
+
+        // Check if we are stopped and there are no more elements in the buffer.
+        if (m_used == 0 && m_stopped.load(std::memory_order::acquire))
+        {
+            completed_waiters   = m_completed_waiters;
+            m_completed_waiters = nullptr;
+        }
+
+        // After this point we will no longer be checking state objects on the buffer
+        lk.unlock();
+
+        // Resume any writer
+        if (writer_to_resume != nullptr)
+        {
+            DCHECK(completed_waiters == nullptr) << "Logic error. Wrote value but count is 0";
+
+            writer_to_resume->resume();
+        }
+
+        // Resume completed if there are any
+        while (completed_waiters != nullptr)
+        {
+            completed_waiters->resume();
+
+            completed_waiters = completed_waiters->m_next;
+        }
+
+        return true;
+    }
+
+    auto try_completed_locked(std::unique_lock<mutex_type>& lk, CompletedOperation* op) -> bool
+    {
+        // Condition is already met, no need to wait
+        if (!m_stopped.load(std::memory_order::acquire) || m_used >= 0)
+        {
+            return false;
+        }
+
+        DCHECK(m_write_waiters == nullptr) << "Should not have any writers with a closed buffer";
+
+        // release lock
+        lk.unlock();
+
+        return true;
+    }
+};
+
+}  // namespace mrc::coroutines

--- a/cpp/mrc/include/mrc/coroutines/schedule_on.hpp
+++ b/cpp/mrc/include/mrc/coroutines/schedule_on.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/include/mrc/coroutines/schedule_on.hpp
+++ b/cpp/mrc/include/mrc/coroutines/schedule_on.hpp
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Original Source: https://github.com/lewissbaker/cppcoro
+ * Original License: MIT; included below
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lewis Baker
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "async_generator.hpp"
+
+#include <boost/type_traits/remove_reference.hpp>
+#include <mrc/coroutines/concepts/awaitable.hpp>
+#include <mrc/coroutines/task.hpp>
+
+#include <type_traits>
+
+namespace mrc::coroutines {
+
+/**
+ * @brief Schedules an awaitable to run on the supplied scheduler. Returns the value as if it were awaited on in the
+ * current thread.
+ */
+template <typename SchedulerT, typename AwaitableT>
+auto schedule_on(SchedulerT& scheduler, AwaitableT awaitable) -> Task<typename boost::detail::remove_rvalue_ref<
+    typename mrc::coroutines::concepts::awaitable_traits<AwaitableT>::awaiter_return_type>::type>
+{
+    using return_t = typename boost::detail::remove_rvalue_ref<
+        typename mrc::coroutines::concepts::awaitable_traits<AwaitableT>::awaiter_return_type>::type;
+
+    co_await scheduler.schedule();
+
+    if constexpr (std::is_same_v<void, return_t>)
+    {
+        co_await std::move(awaitable);
+        VLOG(10) << "schedule_on completed";
+        co_return;
+    }
+    else
+    {
+        auto result = co_await std::move(awaitable);
+        VLOG(10) << "schedule_on completed";
+        co_return std::move(result);
+    }
+}
+
+/**
+ * @brief Schedules an async generator to run on the supplied scheduler. Each value in the generator run on the
+ * scheduler. The return value is the same as if the generator was run on the current thread.
+ *
+ * @tparam T
+ * @tparam SchedulerT
+ * @param scheduler
+ * @param source
+ * @return mrc::coroutines::AsyncGenerator<T>
+ */
+template <typename T, typename SchedulerT>
+mrc::coroutines::AsyncGenerator<T> schedule_on(SchedulerT& scheduler, mrc::coroutines::AsyncGenerator<T> source)
+{
+    // Transfer exection to the scheduler before the implicit calls to
+    // 'co_await begin()' or subsequent calls to `co_await iterator::operator++()`
+    // below. This ensures that all calls to the generator's coroutine_handle<>::resume()
+    // are executed on the execution context of the scheduler.
+    co_await scheduler.schedule();
+
+    const auto iter_end = source.end();
+    auto iter           = co_await source.begin();
+    while (iter != iter_end)
+    {
+        co_yield *iter;
+
+        co_await scheduler.schedule();
+
+        (void)co_await ++iter;
+    }
+}
+
+}  // namespace mrc::coroutines

--- a/cpp/mrc/include/mrc/coroutines/scheduler.hpp
+++ b/cpp/mrc/include/mrc/coroutines/scheduler.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/include/mrc/coroutines/scheduler.hpp
+++ b/cpp/mrc/include/mrc/coroutines/scheduler.hpp
@@ -25,9 +25,12 @@
 #include <mutex>
 #include <string>
 
+// IWYU thinks this is needed, but it's not
+// IWYU pragma: no_include "mrc/coroutines/task_container.hpp"
+
 namespace mrc::coroutines {
 
-class TaskContainer;
+class TaskContainer;  // IWYU pragma: keep
 
 /**
  * @brief Scheduler base class

--- a/cpp/mrc/include/mrc/coroutines/scheduler.hpp
+++ b/cpp/mrc/include/mrc/coroutines/scheduler.hpp
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mrc/core/bitmap.hpp"
+#include "mrc/coroutines/task.hpp"
+#include "mrc/coroutines/task_container.hpp"
+
+#include <coroutine>
+#include <functional>
+#include <memory>
+#include <mutex>
+
+namespace mrc::coroutines {
+
+class TaskContainer;
+
+/**
+ * @brief Scheduler base class
+ *
+ * Allows all schedulers to be discovered via the mrc::this_thread::current_scheduler()
+ */
+class Scheduler : public std::enable_shared_from_this<Scheduler>
+{
+  public:
+    struct Operation
+    {
+        Operation(Scheduler& scheduler);
+
+        constexpr static auto await_ready() noexcept -> bool
+        {
+            return false;
+        }
+
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept;
+
+        constexpr static auto await_resume() noexcept -> void {}
+
+        Scheduler& m_scheduler;
+        std::coroutine_handle<> m_awaiting_coroutine;
+        Operation* m_next{nullptr};
+    };
+
+    Scheduler()          = default;
+    virtual ~Scheduler() = default;
+
+    /**
+     * @brief Description of Scheduler
+     */
+    virtual const std::string& description() const = 0;
+
+    /**
+     * Schedules the currently executing coroutine to be run on this thread pool.  This must be
+     * called from within the coroutines function body to schedule the coroutine on the thread pool.
+     * @throw std::runtime_error If the thread pool is `shutdown()` scheduling new tasks is not permitted.
+     * @return The operation to switch from the calling scheduling thread to the executor thread
+     *         pool thread.
+     */
+    [[nodiscard]] virtual auto schedule() -> Operation;
+
+    // Enqueues a message without waiting for it. Must return void since the caller will not get the return value
+    virtual TaskContainer::StartOperation schedule(Task<void>&& task);
+
+    /**
+     * Schedules any coroutine handle that is ready to be resumed.
+     * @param handle The coroutine handle to schedule.
+     */
+    virtual auto resume(std::coroutine_handle<> coroutine) -> void = 0;
+
+    /**
+     * @brief Runs the selected task until it is complete. Blocks the current thread and may optionally use that thread
+     * for execution.
+     *
+     * @param task The task to run.
+     */
+    virtual void run_until_complete(Task<void> task);
+
+    [[nodiscard]] auto yield() -> Operation;
+
+    /**
+     * If the calling thread controlled by a Scheduler, return a pointer to the Scheduler
+     */
+    static auto from_current_thread() noexcept -> Scheduler*;
+
+    /**
+     * If the calling thread is owned by a thread_pool, return the thread index (rank) of the current thread with
+     * respect the threads in the pool; otherwise, return the std::hash of std::this_thread::get_id
+     */
+    static auto get_thread_id() noexcept -> std::size_t;
+
+  protected:
+    virtual auto on_thread_start(std::size_t) -> void;
+
+    TaskContainer& get_task_container() const;
+
+  private:
+    virtual std::unique_ptr<TaskContainer> make_task_container() const;
+
+    virtual std::coroutine_handle<> schedule_operation(Operation* operation) = 0;
+
+    mutable std::mutex m_mutex;
+
+    std::unique_ptr<TaskContainer> m_task_container;
+
+    thread_local static Scheduler* m_thread_local_scheduler;
+    thread_local static std::size_t m_thread_id;
+};
+
+}  // namespace mrc::coroutines

--- a/cpp/mrc/include/mrc/coroutines/scheduler.hpp
+++ b/cpp/mrc/include/mrc/coroutines/scheduler.hpp
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "mrc/coroutines/task.hpp"
-#include "mrc/coroutines/task_container.hpp"
 
 #include <coroutine>
 #include <cstddef>
@@ -27,6 +26,8 @@
 #include <string>
 
 namespace mrc::coroutines {
+
+class TaskContainer;
 
 /**
  * @brief Scheduler base class
@@ -54,7 +55,7 @@ class Scheduler : public std::enable_shared_from_this<Scheduler>
         Operation* m_next{nullptr};
     };
 
-    Scheduler()          = default;
+    Scheduler();
     virtual ~Scheduler() = default;
 
     /**
@@ -108,14 +109,6 @@ class Scheduler : public std::enable_shared_from_this<Scheduler>
 
   private:
     /**
-     * @brief Builds a task container to maintain the lifetime of fire-and-forget tasks scheduled with
-     * schedule(Task<void>&& task)
-     *
-     * @return std::unique_ptr<TaskContainer>
-     */
-    virtual std::unique_ptr<TaskContainer> make_task_container() const;
-
-    /**
      * @brief When co_await schedule() is called, this function will be executed by the awaiter. Each scheduler
      * implementation should determine how and when to execute the operation.
      *
@@ -127,6 +120,7 @@ class Scheduler : public std::enable_shared_from_this<Scheduler>
 
     mutable std::mutex m_mutex;
 
+    // Maintains the lifetime of fire-and-forget tasks scheduled with schedule(Task<void>&& task)
     std::unique_ptr<TaskContainer> m_task_container;
 
     thread_local static Scheduler* m_thread_local_scheduler;

--- a/cpp/mrc/include/mrc/coroutines/scheduler.hpp
+++ b/cpp/mrc/include/mrc/coroutines/scheduler.hpp
@@ -17,18 +17,16 @@
 
 #pragma once
 
-#include "mrc/core/bitmap.hpp"
 #include "mrc/coroutines/task.hpp"
 #include "mrc/coroutines/task_container.hpp"
 
 #include <coroutine>
-#include <functional>
+#include <cstddef>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace mrc::coroutines {
-
-class TaskContainer;
 
 /**
  * @brief Scheduler base class

--- a/cpp/mrc/include/mrc/coroutines/task_container.hpp
+++ b/cpp/mrc/include/mrc/coroutines/task_container.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/include/mrc/coroutines/task_container.hpp
+++ b/cpp/mrc/include/mrc/coroutines/task_container.hpp
@@ -68,11 +68,14 @@ class TaskContainer
     {
         StartOperation(TaskContainer& parent, Task<void>&& task, GarbageCollectPolicy cleanup);
 
-        constexpr static auto await_ready() noexcept -> bool;
+        constexpr static auto await_ready() noexcept -> bool
+        {
+            return false;
+        }
 
-        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept;
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<> awaiting_coroutine);
 
-        constexpr static auto await_resume() noexcept -> void;
+        constexpr static auto await_resume() noexcept -> void {}
 
         TaskContainer& m_parent;
         Task<void> m_task;

--- a/cpp/mrc/include/mrc/coroutines/task_container.hpp
+++ b/cpp/mrc/include/mrc/coroutines/task_container.hpp
@@ -38,12 +38,11 @@
 
 #pragma once
 
-#include "mrc/coroutines/concepts/executor.hpp"
 #include "mrc/coroutines/task.hpp"
 
 #include <atomic>
+#include <coroutine>
 #include <cstddef>
-#include <iostream>
 #include <list>
 #include <memory>
 #include <mutex>

--- a/cpp/mrc/include/mrc/coroutines/task_container.hpp
+++ b/cpp/mrc/include/mrc/coroutines/task_container.hpp
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Original Source: https://github.com/jbaldwin/libcoro
+ * Original License: Apache License, Version 2.0; included below
+ */
+
+/**
+ * Copyright 2021 Josh Baldwin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "mrc/coroutines/concepts/executor.hpp"
+#include "mrc/coroutines/task.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <iostream>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace mrc::coroutines {
+class Scheduler;
+
+class TaskContainer
+{
+  public:
+    enum class GarbageCollectPolicy
+    {
+        /// Execute garbage collection.
+        yes,
+        /// Do not execute garbage collection.
+        no
+    };
+
+    struct StartOperation
+    {
+        StartOperation(TaskContainer& parent, Task<void>&& task, GarbageCollectPolicy cleanup);
+
+        constexpr static auto await_ready() noexcept -> bool;
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept;
+
+        constexpr static auto await_resume() noexcept -> void;
+
+        TaskContainer& m_parent;
+        Task<void> m_task;
+        GarbageCollectPolicy m_cleanup;
+
+        std::coroutine_handle<> m_awaiting_coroutine;
+    };
+
+    using task_position_t = std::list<std::optional<Task<>>>::iterator;
+
+    /**
+     * @param e Tasks started in the container are scheduled onto this executor.  For tasks created
+     *           from a coro::io_scheduler, this would usually be that coro::io_scheduler instance.
+     * @param opts Task container options.
+     */
+    TaskContainer(std::shared_ptr<Scheduler> e, std::size_t concurrency = 1024);
+    TaskContainer(const TaskContainer&)                    = delete;
+    TaskContainer(TaskContainer&&)                         = delete;
+    auto operator=(const TaskContainer&) -> TaskContainer& = delete;
+    auto operator=(TaskContainer&&) -> TaskContainer&      = delete;
+    ~TaskContainer();
+
+    /**
+     * Stores a user task and starts its execution on the container's thread pool.
+     * @param user_task The scheduled user's task to store in this task container and start its execution.
+     * @param cleanup Should the task container run garbage collect at the beginning of this store
+     *                call?  Calling at regular intervals will reduce memory usage of completed
+     *                tasks and allow for the task container to re-use allocated space.
+     */
+    StartOperation start(Task<void>&& user_task, GarbageCollectPolicy cleanup = GarbageCollectPolicy::yes);
+
+    /**
+     * Garbage collects any tasks that are marked as deleted.  This frees up space to be re-used by
+     * the task container for newly stored tasks.
+     * @return The number of tasks that were deleted.
+     */
+    auto garbage_collect() -> std::size_t;  // __attribute__((used))
+
+    /**
+     * @return The number of tasks that are awaiting deletion.
+     */
+    auto delete_task_size() const -> std::size_t;
+
+    /**
+     * @return True if there are no tasks awaiting deletion.
+     */
+    auto delete_tasks_empty() const -> bool;
+
+    /**
+     * @return The number of active tasks in the container.
+     */
+    auto size() const -> std::size_t;
+
+    /**
+     * @return True if there are no active tasks in the container.
+     */
+    auto empty() const -> bool;
+
+    /**
+     * Will continue to garbage collect and yield until all tasks are complete.  This method can be
+     * co_await'ed to make it easier to wait for the task container to have all its tasks complete.
+     *
+     * This does not shut down the task container, but can be used when shutting down, or if your
+     * logic requires all the tasks contained within to complete, it is similar to coro::latch.
+     */
+    auto garbage_collect_and_yield_until_empty() -> Task<void>;
+
+  private:
+    /**
+     * Interal GC call, expects the public function to lock.
+     */
+    auto gc_internal() -> std::size_t;
+
+    /**
+     * Encapsulate the users tasks in a cleanup task which marks itself for deletion upon
+     * completion.  Simply co_await the users task until its completed and then mark the given
+     * position within the task manager as being deletable.  The scheduler's next iteration
+     * in its event loop will then free that position up to be re-used.
+     *
+     * This function will also unconditionally catch all unhandled exceptions by the user's
+     * task to prevent the scheduler from throwing exceptions.
+     * @param user_task The user's task.
+     * @param pos The position where the task data will be stored in the task manager.
+     * @return The user's task wrapped in a self cleanup task.
+     */
+    auto make_cleanup_task(Task<void> user_task, task_position_t pos) -> Task<void>;
+
+    /**
+     * @brief Starts the task associated with the provided operator.
+     *
+     * @param lock Move a lock into this function to prevent locking and relocking issues
+     * @param op Operator to start
+     * @return std::coroutine_handle<> Returns a handle to the operator's coroutine which should be `resume()`. This
+     * value is returned instead of called directly to allow it to be used as the return value in await_suspend()
+     */
+    virtual auto do_start(std::unique_lock<std::mutex>&& lock, StartOperation* op) -> std::coroutine_handle<>;
+
+    /**
+     * @brief Implements the scheduling of the start() call. Can possibly block depending on the number of outstanding
+     * tasks.
+     *
+     * @param op The awaitable operation to schedule
+     * @return std::coroutine_handle<> Returns a handle to the operator's coroutine which should be `resume()`. This is
+     * returned instead of called directly to allow it to be used as the return value in await_suspend()
+     */
+    virtual std::coroutine_handle<> schedule_start_operation(StartOperation* op);
+
+    /// Mutex for safely mutating the task containers across threads, expected usage is within
+    /// thread pools for indeterminate lifetime requests.
+    std::mutex m_mutex{};
+    /// The max number of concurrent tasks
+    std::size_t m_concurrency{1024};
+    /// The number of alive tasks.
+    std::atomic<std::size_t> m_size{};
+    /// Maintains the lifetime of the tasks until they are completed.
+    std::list<std::optional<Task<void>>> m_tasks{};
+    /// The set of tasks that have completed and need to be deleted.
+    std::vector<task_position_t> m_tasks_to_delete{};
+    /// The current free position within the task indexes list.  Anything before
+    std::shared_ptr<Scheduler> m_scheduler{nullptr};
+
+    std::list<StartOperation*> m_waiting_start_operations;
+};
+
+}  // namespace mrc::coroutines

--- a/cpp/mrc/src/internal/codable/decodable_storage_view.cpp
+++ b/cpp/mrc/src/internal/codable/decodable_storage_view.cpp
@@ -37,7 +37,6 @@
 #include <cstring>
 #include <optional>
 #include <ostream>
-#include <string>
 
 namespace mrc::codable {
 

--- a/cpp/mrc/src/internal/codable/storage_view.cpp
+++ b/cpp/mrc/src/internal/codable/storage_view.cpp
@@ -19,7 +19,6 @@
 
 #include <glog/logging.h>
 
-#include <cstdint>
 #include <optional>
 
 namespace mrc::codable {

--- a/cpp/mrc/src/internal/control_plane/client/connections_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/connections_manager.cpp
@@ -31,7 +31,6 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <cstdint>
 #include <iterator>
 #include <ostream>
 #include <set>

--- a/cpp/mrc/src/internal/control_plane/client/state_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/client/state_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "mrc/core/error.hpp"
 #include "mrc/edge/edge_builder.hpp"
+#include "mrc/edge/edge_writable.hpp"
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/protos/architect.pb.h"
 #include "mrc/runnable/launch_control.hpp"

--- a/cpp/mrc/src/internal/control_plane/server/connection_manager.cpp
+++ b/cpp/mrc/src/internal/control_plane/server/connection_manager.cpp
@@ -27,7 +27,6 @@
 #include <glog/logging.h>
 #include <google/protobuf/any.pb.h>
 
-#include <cstdint>
 #include <sstream>
 #include <utility>
 

--- a/cpp/mrc/src/internal/memory/device_resources.cpp
+++ b/cpp/mrc/src/internal/memory/device_resources.cpp
@@ -35,16 +35,12 @@
 #include "mrc/types.hpp"
 #include "mrc/utils/bytes_to_string.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 
-#include <map>
-#include <set>
 #include <sstream>
 #include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 
 namespace mrc::memory {
 

--- a/cpp/mrc/src/internal/memory/host_resources.cpp
+++ b/cpp/mrc/src/internal/memory/host_resources.cpp
@@ -35,13 +35,10 @@
 #include "mrc/types.hpp"
 #include "mrc/utils/bytes_to_string.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 
-#include <map>
 #include <memory>
 #include <ostream>
-#include <set>
 #include <string>
 #include <thread>
 #include <utility>

--- a/cpp/mrc/src/internal/network/network_resources.cpp
+++ b/cpp/mrc/src/internal/network/network_resources.cpp
@@ -27,7 +27,6 @@
 #include "mrc/core/task_queue.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 
 #include <utility>

--- a/cpp/mrc/src/internal/pipeline/controller.cpp
+++ b/cpp/mrc/src/internal/pipeline/controller.cpp
@@ -31,12 +31,10 @@
 #include <algorithm>
 #include <exception>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <set>
 #include <utility>
-#include <vector>
 
 namespace mrc::pipeline {
 

--- a/cpp/mrc/src/internal/pubsub/publisher_service.cpp
+++ b/cpp/mrc/src/internal/pubsub/publisher_service.cpp
@@ -39,10 +39,8 @@
 #include <glog/logging.h>
 #include <rxcpp/rx.hpp>
 
-#include <map>
 #include <optional>
 #include <utility>
-#include <vector>
 
 namespace mrc::pubsub {
 

--- a/cpp/mrc/src/internal/pubsub/subscriber_service.cpp
+++ b/cpp/mrc/src/internal/pubsub/subscriber_service.cpp
@@ -27,6 +27,7 @@
 #include "internal/runtime/partition.hpp"
 
 #include "mrc/edge/edge_builder.hpp"
+#include "mrc/edge/edge_writable.hpp"
 #include "mrc/node/operators/router.hpp"
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/protos/codable.pb.h"
@@ -41,7 +42,6 @@
 #include <optional>
 #include <ostream>
 #include <utility>
-#include <vector>
 
 namespace mrc::pubsub {
 

--- a/cpp/mrc/src/internal/runnable/fiber_engine.cpp
+++ b/cpp/mrc/src/internal/runnable/fiber_engine.cpp
@@ -21,8 +21,6 @@
 #include "mrc/runnable/types.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
-
 #include <utility>
 
 namespace mrc::runnable {

--- a/cpp/mrc/src/internal/runnable/fiber_engines.cpp
+++ b/cpp/mrc/src/internal/runnable/fiber_engines.cpp
@@ -27,7 +27,6 @@
 
 #include <memory>
 #include <ostream>
-#include <string>
 #include <utility>
 
 namespace mrc::runnable {

--- a/cpp/mrc/src/internal/runnable/runnable_resources.cpp
+++ b/cpp/mrc/src/internal/runnable/runnable_resources.cpp
@@ -27,7 +27,6 @@
 #include "mrc/runnable/types.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 
 #include <map>

--- a/cpp/mrc/src/internal/runnable/thread_engine.cpp
+++ b/cpp/mrc/src/internal/runnable/thread_engine.cpp
@@ -24,7 +24,6 @@
 #include "mrc/runnable/types.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <boost/fiber/future/packaged_task.hpp>
 
 #include <optional>

--- a/cpp/mrc/src/internal/runnable/thread_engines.cpp
+++ b/cpp/mrc/src/internal/runnable/thread_engines.cpp
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <memory>
 #include <ostream>
-#include <string>
 #include <utility>
 
 namespace mrc::runnable {

--- a/cpp/mrc/src/internal/segment/builder_definition.cpp
+++ b/cpp/mrc/src/internal/segment/builder_definition.cpp
@@ -28,9 +28,9 @@
 #include "mrc/modules/properties/persistent.hpp"  // IWYU pragma: keep
 #include "mrc/modules/segment_modules.hpp"
 #include "mrc/node/port_registry.hpp"
+#include "mrc/runnable/launchable.hpp"
 #include "mrc/segment/egress_port.hpp"   // IWYU pragma: keep
 #include "mrc/segment/ingress_port.hpp"  // IWYU pragma: keep
-#include "mrc/segment/initializers.hpp"
 #include "mrc/segment/object.hpp"
 #include "mrc/types.hpp"
 

--- a/cpp/mrc/src/internal/system/host_partition_provider.cpp
+++ b/cpp/mrc/src/internal/system/host_partition_provider.cpp
@@ -17,6 +17,7 @@
 
 #include "internal/system/host_partition_provider.hpp"
 
+#include "internal/system/host_partition.hpp"
 #include "internal/system/partitions.hpp"
 #include "internal/system/system.hpp"
 
@@ -25,7 +26,6 @@
 #include <vector>
 
 namespace mrc::system {
-class HostPartition;
 
 HostPartitionProvider::HostPartitionProvider(const SystemProvider& _system, std::size_t _host_partition_id) :
   SystemProvider(_system),

--- a/cpp/mrc/src/internal/system/partition_provider.cpp
+++ b/cpp/mrc/src/internal/system/partition_provider.cpp
@@ -17,6 +17,7 @@
 
 #include "internal/system/partition_provider.hpp"
 
+#include "internal/system/partition.hpp"
 #include "internal/system/partitions.hpp"
 #include "internal/system/system.hpp"
 

--- a/cpp/mrc/src/internal/system/threading_resources.cpp
+++ b/cpp/mrc/src/internal/system/threading_resources.cpp
@@ -19,9 +19,10 @@
 
 #include "internal/system/fiber_manager.hpp"
 
+#include "mrc/types.hpp"
+
 #include <boost/fiber/future/future.hpp>
 
-#include <map>
 #include <vector>
 
 namespace mrc::system {

--- a/cpp/mrc/src/internal/ucx/receive_manager.cpp
+++ b/cpp/mrc/src/internal/ucx/receive_manager.cpp
@@ -23,7 +23,6 @@
 #include "mrc/types.hpp"
 
 #include <boost/fiber/future/async.hpp>
-#include <boost/fiber/future/future.hpp>
 #include <boost/fiber/operations.hpp>
 #include <boost/fiber/policy.hpp>  // for launch, launch::post
 #include <ucp/api/ucp.h>           // for ucp_tag_probe_nb, ucp_tag_recv_info

--- a/cpp/mrc/src/internal/ucx/ucx_resources.cpp
+++ b/cpp/mrc/src/internal/ucx/ucx_resources.cpp
@@ -30,7 +30,6 @@
 #include "mrc/cuda/common.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <cuda_runtime.h>
 #include <glog/logging.h>
 

--- a/cpp/mrc/src/public/core/thread.cpp
+++ b/cpp/mrc/src/public/core/thread.cpp
@@ -20,7 +20,6 @@
 #include "mrc/coroutines/thread_pool.hpp"
 
 #include <concepts>
-#include <cstddef>
 #include <iomanip>
 #include <sstream>
 #include <thread>

--- a/cpp/mrc/src/public/coroutines/scheduler.cpp
+++ b/cpp/mrc/src/public/coroutines/scheduler.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/src/public/coroutines/scheduler.cpp
+++ b/cpp/mrc/src/public/coroutines/scheduler.cpp
@@ -19,7 +19,9 @@
 
 #include <glog/logging.h>
 
+#include <ostream>
 #include <thread>
+#include <utility>
 
 namespace mrc::coroutines {
 

--- a/cpp/mrc/src/public/coroutines/scheduler.cpp
+++ b/cpp/mrc/src/public/coroutines/scheduler.cpp
@@ -39,6 +39,8 @@ std::coroutine_handle<> Scheduler::Operation::await_suspend(std::coroutine_handl
     return m_scheduler.schedule_operation(this);
 }
 
+Scheduler::Scheduler() : m_task_container(new TaskContainer(*this)) {}
+
 auto Scheduler::schedule() -> Operation
 {
     return Operation{*this};
@@ -78,11 +80,6 @@ auto Scheduler::on_thread_start(std::size_t thread_id) -> void
 TaskContainer& Scheduler::get_task_container() const
 {
     return *m_task_container;
-}
-
-std::unique_ptr<TaskContainer> Scheduler::make_task_container() const
-{
-    return std::unique_ptr<TaskContainer>(new TaskContainer(*const_cast<Scheduler*>(this)));
 }
 
 }  // namespace mrc::coroutines

--- a/cpp/mrc/src/public/coroutines/task_container.cpp
+++ b/cpp/mrc/src/public/coroutines/task_container.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/src/public/coroutines/task_container.cpp
+++ b/cpp/mrc/src/public/coroutines/task_container.cpp
@@ -166,7 +166,6 @@ auto TaskContainer::make_cleanup_task(Task<void> user_task, task_position_t pos)
         // Call do_start and immediately resume the coroutine.
         auto waiting_coro = this->do_start(std::move(lock), op);
 
-        VLOG(10) << "Resuming handle: " << waiting_coro.address();
         waiting_coro.resume();
     }
     else

--- a/cpp/mrc/src/public/coroutines/task_container.cpp
+++ b/cpp/mrc/src/public/coroutines/task_container.cpp
@@ -19,8 +19,6 @@
 
 #include "mrc/coroutines/scheduler.hpp"
 
-#include <glog/logging.h>
-
 #include <exception>
 #include <iostream>
 #include <mutex>

--- a/cpp/mrc/src/public/coroutines/task_container.cpp
+++ b/cpp/mrc/src/public/coroutines/task_container.cpp
@@ -21,8 +21,10 @@
 
 #include <glog/logging.h>
 
+#include <exception>
+#include <iostream>
 #include <mutex>
-#include <thread>
+#include <stdexcept>
 #include <utility>
 
 namespace mrc::coroutines {

--- a/cpp/mrc/src/public/coroutines/task_container.cpp
+++ b/cpp/mrc/src/public/coroutines/task_container.cpp
@@ -33,18 +33,11 @@ TaskContainer::StartOperation::StartOperation(TaskContainer& parent, Task<void>&
   m_cleanup(cleanup)
 {}
 
-constexpr auto TaskContainer::StartOperation::await_ready() noexcept -> bool
-{
-    return false;
-}
-
-auto TaskContainer::StartOperation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept
+std::coroutine_handle<> TaskContainer::StartOperation::await_suspend(std::coroutine_handle<> awaiting_coroutine)
 {
     m_awaiting_coroutine = awaiting_coroutine;
     return m_parent.schedule_start_operation(this);
 }
-
-constexpr auto TaskContainer::StartOperation::await_resume() noexcept -> void {}
 
 TaskContainer::TaskContainer(std::shared_ptr<Scheduler> e, std::size_t concurrency) :
   m_scheduler(std::move(e)),

--- a/cpp/mrc/src/public/coroutines/task_container.cpp
+++ b/cpp/mrc/src/public/coroutines/task_container.cpp
@@ -1,0 +1,226 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mrc/coroutines/task_container.hpp"
+
+#include "mrc/coroutines/scheduler.hpp"
+
+#include <glog/logging.h>
+
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace mrc::coroutines {
+
+TaskContainer::StartOperation::StartOperation(TaskContainer& parent, Task<void>&& task, GarbageCollectPolicy cleanup) :
+  m_parent(parent),
+  m_task(std::move(task)),
+  m_cleanup(cleanup)
+{}
+
+constexpr auto TaskContainer::StartOperation::await_ready() noexcept -> bool
+{
+    return false;
+}
+
+auto TaskContainer::StartOperation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept
+{
+    m_awaiting_coroutine = awaiting_coroutine;
+    return m_parent.schedule_start_operation(this);
+}
+
+constexpr auto TaskContainer::StartOperation::await_resume() noexcept -> void {}
+
+TaskContainer::TaskContainer(std::shared_ptr<Scheduler> e, std::size_t concurrency) :
+  m_scheduler(std::move(e)),
+  m_concurrency(concurrency)
+{
+    if (m_scheduler == nullptr)
+    {
+        throw std::runtime_error{"task_container cannot have a nullptr executor"};
+    }
+}
+
+TaskContainer::~TaskContainer()
+{
+    // This will hang the current thread.. but if tasks are not complete thats also pretty bad.
+    while (!empty())
+    {
+        garbage_collect();
+    }
+}
+
+TaskContainer::StartOperation TaskContainer::start(Task<void>&& task, GarbageCollectPolicy cleanup)
+{
+    return StartOperation{*this, std::move(task), cleanup};
+}
+
+auto TaskContainer::garbage_collect() -> std::size_t  // __attribute__((used))
+{
+    std::lock_guard lk{m_mutex};
+    return gc_internal();
+}
+
+auto TaskContainer::delete_task_size() const -> std::size_t
+{
+    std::atomic_thread_fence(std::memory_order::acquire);
+    return m_tasks_to_delete.size();
+}
+
+auto TaskContainer::delete_tasks_empty() const -> bool
+{
+    std::atomic_thread_fence(std::memory_order::acquire);
+    return m_tasks_to_delete.empty();
+}
+
+auto TaskContainer::size() const -> std::size_t
+{
+    return m_size.load(std::memory_order::relaxed);
+}
+
+auto TaskContainer::empty() const -> bool
+{
+    return size() == 0;
+}
+
+auto TaskContainer::garbage_collect_and_yield_until_empty() -> Task<void>
+{
+    while (!empty())
+    {
+        garbage_collect();
+        co_await m_scheduler->yield();
+    }
+}
+
+auto TaskContainer::gc_internal() -> std::size_t
+{
+    std::size_t deleted{0};
+    if (!m_tasks_to_delete.empty())
+    {
+        for (const auto& pos : m_tasks_to_delete)
+        {
+            if (pos->has_value())
+            {
+                pos->value().destroy();
+            }
+            m_tasks.erase(pos);
+        }
+        deleted = m_tasks_to_delete.size();
+        m_tasks_to_delete.clear();
+    }
+    return deleted;
+}
+
+auto TaskContainer::make_cleanup_task(Task<void> user_task, task_position_t pos) -> Task<void>
+{
+    // Immediately move the task onto the executor.
+    co_await m_scheduler->schedule();
+
+    try
+    {
+        // Await the users task to complete.
+        co_await user_task;
+    } catch (const std::exception& e)
+    {
+        // what would be a good way to report this to the user...?  Catching here is required
+        // since the co_await will unwrap the unhandled exception on the task.
+        // The user's task should ideally be wrapped in a catch all and handle it themselves, but
+        // that cannot be guaranteed.
+        std::cerr << "Task_container user_task had an unhandled exception e.what()= " << e.what() << "\n";
+    } catch (...)
+    {
+        // don't crash if they throw something that isn't derived from std::exception
+        std::cerr << "Task_container user_task had unhandle exception, not derived from std::exception.\n";
+    }
+
+    std::unique_lock lock{m_mutex};
+
+    m_size.fetch_sub(1, std::memory_order::relaxed);
+
+    // Check for waiting start operations
+    if (!m_waiting_start_operations.empty())
+    {
+        auto* op = m_waiting_start_operations.front();
+        m_waiting_start_operations.pop_front();
+
+        // We must run GC before adding this to the tasks to delete, otherwise we will delete this task while it is
+        // still running
+        if (op->m_cleanup == GarbageCollectPolicy::yes)
+        {
+            gc_internal();
+        }
+
+        // Defer adding to the tasks to delete until after GC is run
+        m_tasks_to_delete.push_back(pos);
+
+        // Call do_start and immediately resume the coroutine.
+        auto waiting_coro = this->do_start(std::move(lock), op);
+
+        VLOG(10) << "Resuming handle: " << waiting_coro.address();
+        waiting_coro.resume();
+    }
+    else
+    {
+        // No waiting start operations, schedule this to be deleted
+        m_tasks_to_delete.push_back(pos);
+    }
+
+    co_return;
+}
+
+auto TaskContainer::do_start(std::unique_lock<std::mutex>&& lock, StartOperation* op) -> std::coroutine_handle<>
+{
+    // Take ownership of the lock object
+    auto local_lock = std::move(lock);
+
+    m_size.fetch_add(1, std::memory_order::relaxed);
+
+    // Store the task inside a cleanup task for self deletion.
+    auto pos = m_tasks.emplace(m_tasks.end(), std::nullopt);
+
+    auto task = make_cleanup_task(std::move(op->m_task), pos);
+
+    *pos = std::move(task);
+
+    // Start executing from the cleanup task to schedule the user's task onto the thread pool.
+    pos->value().resume();
+
+    return std::move(op->m_awaiting_coroutine);
+}
+
+std::coroutine_handle<> TaskContainer::schedule_start_operation(StartOperation* op)
+{
+    std::unique_lock lock(m_mutex);
+
+    if (m_size < m_concurrency)
+    {
+        // If op requested a GC before starting, do that now while we have the Mutex
+        if (op->m_cleanup == GarbageCollectPolicy::yes)
+        {
+            gc_internal();
+        }
+
+        return this->do_start(std::move(lock), op);
+    }
+
+    m_waiting_start_operations.push_back(op);
+
+    return std::noop_coroutine();
+}
+
+}  // namespace mrc::coroutines

--- a/cpp/mrc/src/public/coroutines/thread_pool.cpp
+++ b/cpp/mrc/src/public/coroutines/thread_pool.cpp
@@ -39,7 +39,6 @@
 #include "mrc/coroutines/thread_pool.hpp"
 
 #include <cstddef>
-#include <future>
 #include <iostream>
 #include <stdexcept>
 

--- a/cpp/mrc/src/public/modules/sample_modules.cpp
+++ b/cpp/mrc/src/public/modules/sample_modules.cpp
@@ -26,10 +26,8 @@
 
 #include <glog/logging.h>
 
-#include <map>
 #include <memory>
 #include <ostream>
-#include <vector>
 
 namespace mrc::modules {
 

--- a/cpp/mrc/src/tests/nodes/common_nodes.cpp
+++ b/cpp/mrc/src/tests/nodes/common_nodes.cpp
@@ -28,13 +28,11 @@
 #include <rxcpp/rx.hpp>
 
 #include <chrono>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
-#include <vector>
 
 using namespace mrc;
 using namespace mrc::memory::literals;

--- a/cpp/mrc/src/tests/nodes/common_nodes.hpp
+++ b/cpp/mrc/src/tests/nodes/common_nodes.hpp
@@ -30,7 +30,6 @@
 #include <array>
 #include <cstddef>
 #include <memory>
-#include <utility>
 
 namespace test::nodes {
 

--- a/cpp/mrc/src/tests/pipelines/multi_segment.cpp
+++ b/cpp/mrc/src/tests/pipelines/multi_segment.cpp
@@ -18,7 +18,9 @@
 #include "common_pipelines.hpp"
 
 #include "mrc/node/rx_sink.hpp"
+#include "mrc/node/rx_sink_base.hpp"
 #include "mrc/node/rx_source.hpp"
+#include "mrc/node/rx_source_base.hpp"
 #include "mrc/pipeline/pipeline.hpp"
 #include "mrc/segment/builder.hpp"
 #include "mrc/segment/egress_ports.hpp"
@@ -29,11 +31,8 @@
 #include <glog/logging.h>
 #include <rxcpp/rx.hpp>
 
-#include <map>
 #include <memory>
 #include <ostream>
-#include <string>
-#include <vector>
 
 using namespace mrc;
 

--- a/cpp/mrc/src/tests/segments/common_segments.cpp
+++ b/cpp/mrc/src/tests/segments/common_segments.cpp
@@ -28,7 +28,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 using namespace mrc;
 

--- a/cpp/mrc/src/tests/test_grpc.cpp
+++ b/cpp/mrc/src/tests/test_grpc.cpp
@@ -43,21 +43,16 @@
 #include "mrc/runnable/runner.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <glog/logging.h>
 #include <grpcpp/grpcpp.h>
 #include <gtest/gtest.h>
 #include <rxcpp/rx.hpp>
 
 #include <chrono>
-#include <cstddef>
-#include <map>
 #include <memory>
 #include <ostream>
-#include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 
 // Avoid forward declaring template specialization base classes
 // IWYU pragma: no_forward_declare grpc::ServerAsyncReaderWriter

--- a/cpp/mrc/src/tests/test_memory.cpp
+++ b/cpp/mrc/src/tests/test_memory.cpp
@@ -38,11 +38,9 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <set>
 #include <string>
 #include <thread>
 #include <utility>

--- a/cpp/mrc/src/tests/test_network.cpp
+++ b/cpp/mrc/src/tests/test_network.cpp
@@ -38,6 +38,7 @@
 #include "internal/ucx/registration_cache.hpp"
 
 #include "mrc/edge/edge_builder.hpp"
+#include "mrc/edge/edge_writable.hpp"
 #include "mrc/memory/adaptors.hpp"
 #include "mrc/memory/buffer.hpp"
 #include "mrc/memory/literals.hpp"
@@ -62,15 +63,11 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <set>
-#include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 
 using namespace mrc;
 using namespace mrc::memory::literals;

--- a/cpp/mrc/src/tests/test_next.cpp
+++ b/cpp/mrc/src/tests/test_next.cpp
@@ -25,6 +25,7 @@
 #include "mrc/channel/ingress.hpp"
 #include "mrc/data/reusable_pool.hpp"
 #include "mrc/edge/edge_builder.hpp"
+#include "mrc/edge/edge_writable.hpp"
 #include "mrc/node/generic_node.hpp"
 #include "mrc/node/generic_sink.hpp"
 #include "mrc/node/generic_source.hpp"
@@ -64,12 +65,10 @@
 #include <cstddef>
 #include <exception>
 #include <functional>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
-#include <vector>
 
 using namespace mrc;
 
@@ -573,7 +572,7 @@ TEST_F(TestNext, RxWithReusableOnNextAndOnError)
     });
 
     static_assert(rxcpp::detail::is_on_next_of<data_t, std::function<void(data_t)>>::value, " ");
-    static_assert(rxcpp::detail::is_on_next_of<data_t, std::function<void(data_t &&)>>::value, " ");
+    static_assert(rxcpp::detail::is_on_next_of<data_t, std::function<void(data_t&&)>>::value, " ");
 
     auto observer = rxcpp::make_observer_dynamic<data_t>(
         [](data_t&& int_ptr) {

--- a/cpp/mrc/src/tests/test_remote_descriptor.cpp
+++ b/cpp/mrc/src/tests/test_remote_descriptor.cpp
@@ -39,7 +39,6 @@
 #include "mrc/runtime/remote_descriptor_handle.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <boost/fiber/operations.hpp>
 #include <gtest/gtest.h>
 

--- a/cpp/mrc/src/tests/test_resources.cpp
+++ b/cpp/mrc/src/tests/test_resources.cpp
@@ -28,7 +28,6 @@
 #include "mrc/options/placement.hpp"
 #include "mrc/types.hpp"
 
-#include <boost/fiber/future/future.hpp>
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/cpp/mrc/src/tests/test_runnable.cpp
+++ b/cpp/mrc/src/tests/test_runnable.cpp
@@ -47,14 +47,12 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <thread>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 using namespace mrc;
 

--- a/cpp/mrc/src/tests/test_ucx.cpp
+++ b/cpp/mrc/src/tests/test_ucx.cpp
@@ -39,7 +39,6 @@
 #include <memory>
 #include <ostream>
 #include <stdexcept>
-#include <string>
 
 using namespace mrc;
 using namespace ucx;

--- a/cpp/mrc/tests/CMakeLists.txt
+++ b/cpp/mrc/tests/CMakeLists.txt
@@ -15,9 +15,11 @@
 
 # Keep all source files sorted!!!
 add_executable(test_mrc
+  coroutines/test_async_generator.cpp
   coroutines/test_event.cpp
   coroutines/test_latch.cpp
   coroutines/test_ring_buffer.cpp
+  coroutines/test_task_container.cpp
   coroutines/test_task.cpp
   modules/test_mirror_tap_module.cpp
   modules/test_mirror_tap_orchestrator.cpp

--- a/cpp/mrc/tests/benchmarking/test_benchmarking.hpp
+++ b/cpp/mrc/tests/benchmarking/test_benchmarking.hpp
@@ -31,13 +31,11 @@
 #include <rxcpp/rx.hpp>
 
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <random>
 #include <set>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace mrc {
 

--- a/cpp/mrc/tests/benchmarking/test_stat_gather.hpp
+++ b/cpp/mrc/tests/benchmarking/test_stat_gather.hpp
@@ -29,14 +29,12 @@
 #include <rxcpp/rx.hpp>
 
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <random>
 #include <set>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace mrc {
 class TestSegmentResources;

--- a/cpp/mrc/tests/coroutines/test_async_generator.cpp
+++ b/cpp/mrc/tests/coroutines/test_async_generator.cpp
@@ -22,8 +22,6 @@
 #include <gtest/gtest.h>
 
 #include <coroutine>
-#include <string>
-#include <thread>
 
 using namespace mrc;
 

--- a/cpp/mrc/tests/coroutines/test_async_generator.cpp
+++ b/cpp/mrc/tests/coroutines/test_async_generator.cpp
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mrc/coroutines/async_generator.hpp"
+#include "mrc/coroutines/sync_wait.hpp"
+#include "mrc/coroutines/task.hpp"
+
+#include <gtest/gtest.h>
+
+#include <coroutine>
+#include <string>
+#include <thread>
+
+using namespace mrc;
+
+class TestCoroAsyncGenerator : public ::testing::Test
+{};
+
+TEST_F(TestCoroAsyncGenerator, Iterator)
+{
+    auto generator = []() -> coroutines::AsyncGenerator<int> {
+        for (int i = 0; i < 2; i++)
+        {
+            co_yield i;
+        }
+    }();
+
+    auto task = [&]() -> coroutines::Task<> {
+        auto iter = co_await generator.begin();
+
+        EXPECT_TRUE(iter);
+        EXPECT_EQ(*iter, 0);
+        EXPECT_NE(iter, generator.end());
+
+        co_await ++iter;
+
+        EXPECT_TRUE(iter);
+        EXPECT_EQ(*iter, 1);
+        EXPECT_NE(iter, generator.end());
+
+        co_await ++iter;
+        EXPECT_FALSE(iter);
+        EXPECT_EQ(iter, generator.end());
+
+        co_return;
+    };
+
+    coroutines::sync_wait(task());
+}
+
+TEST_F(TestCoroAsyncGenerator, LoopOnGenerator)
+{
+    auto generator = []() -> coroutines::AsyncGenerator<int> {
+        for (int i = 0; i < 2; i++)
+        {
+            co_yield i;
+        }
+    }();
+
+    auto task = [&]() -> coroutines::Task<> {
+        for (int i = 0; i < 2; i++)
+        {
+            auto iter = co_await generator.begin();
+
+            EXPECT_TRUE(iter);
+            EXPECT_EQ(*iter, 0);
+            EXPECT_NE(iter, generator.end());
+
+            co_await ++iter;
+
+            EXPECT_TRUE(iter);
+            EXPECT_EQ(*iter, 1);
+            EXPECT_NE(iter, generator.end());
+
+            co_await ++iter;
+            EXPECT_FALSE(iter);
+            EXPECT_EQ(iter, generator.end());
+
+            co_return;
+        }
+    };
+
+    coroutines::sync_wait(task());
+}
+
+TEST_F(TestCoroAsyncGenerator, MultipleBegins)
+{
+    auto generator = []() -> coroutines::AsyncGenerator<int> {
+        for (int i = 0; i < 2; i++)
+        {
+            co_yield i;
+        }
+    }();
+
+    // this test shows that begin() and operator++() perform essentially the same function
+    // both advance the generator to the next state
+    // while a generator is an iterable, it doesn't hold the entire sequence in memory, it does
+    // what it suggests, it generates the next item from the previous
+
+    auto task = [&]() -> coroutines::Task<> {
+        auto iter = co_await generator.begin();
+
+        EXPECT_TRUE(iter);
+        EXPECT_EQ(*iter, 0);
+        EXPECT_NE(iter, generator.end());
+
+        iter = co_await generator.begin();
+
+        EXPECT_TRUE(iter);
+        EXPECT_EQ(*iter, 1);
+        EXPECT_NE(iter, generator.end());
+
+        iter = co_await generator.begin();
+        EXPECT_FALSE(iter);
+        EXPECT_EQ(iter, generator.end());
+
+        co_return;
+    };
+
+    coroutines::sync_wait(task());
+}

--- a/cpp/mrc/tests/coroutines/test_event.cpp
+++ b/cpp/mrc/tests/coroutines/test_event.cpp
@@ -48,7 +48,6 @@
 #include <atomic>
 #include <coroutine>
 #include <cstdint>
-#include <string>
 #include <tuple>
 
 using namespace mrc;

--- a/cpp/mrc/tests/coroutines/test_latch.cpp
+++ b/cpp/mrc/tests/coroutines/test_latch.cpp
@@ -44,7 +44,6 @@
 
 #include <coroutine>
 #include <cstdint>
-#include <string>
 
 using namespace mrc;
 

--- a/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
+++ b/cpp/mrc/tests/coroutines/test_ring_buffer.cpp
@@ -49,7 +49,6 @@
 #include <coroutine>
 #include <cstddef>
 #include <cstdint>
-#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/cpp/mrc/tests/coroutines/test_task.cpp
+++ b/cpp/mrc/tests/coroutines/test_task.cpp
@@ -49,9 +49,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <string>
 #include <tuple>
-#include <type_traits>
 
 using namespace mrc;
 

--- a/cpp/mrc/tests/coroutines/test_task_container.cpp
+++ b/cpp/mrc/tests/coroutines/test_task_container.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/tests/coroutines/test_task_container.cpp
+++ b/cpp/mrc/tests/coroutines/test_task_container.cpp
@@ -15,18 +15,7 @@
  * limitations under the License.
  */
 
-#include "mrc/coroutines/task.hpp"
-#include "mrc/coroutines/task_container.hpp"
-
-using namespace mrc;
-using namespace mrc::coroutines;
-
 #include <gtest/gtest.h>
-
-#include <chrono>
-#include <thread>
-
-using namespace mrc;
 
 class TestCoroTaskContainer : public ::testing::Test
 {};

--- a/cpp/mrc/tests/coroutines/test_task_container.cpp
+++ b/cpp/mrc/tests/coroutines/test_task_container.cpp
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mrc/coroutines/task.hpp"
+#include "mrc/coroutines/task_container.hpp"
+
+using namespace mrc;
+using namespace mrc::coroutines;
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+using namespace mrc;
+
+class TestCoroTaskContainer : public ::testing::Test
+{};
+
+TEST_F(TestCoroTaskContainer, LifeCycle) {}

--- a/cpp/mrc/tests/logging/test_logging.cpp
+++ b/cpp/mrc/tests/logging/test_logging.cpp
@@ -21,8 +21,6 @@
 
 #include <glog/logging.h>
 
-#include <string>
-
 namespace mrc {
 
 TEST_CLASS(Logging);

--- a/cpp/mrc/tests/modules/dynamic_module.cpp
+++ b/cpp/mrc/tests/modules/dynamic_module.cpp
@@ -19,13 +19,13 @@
 #include "mrc/modules/segment_modules.hpp"
 #include "mrc/node/rx_source.hpp"
 #include "mrc/segment/builder.hpp"
+#include "mrc/segment/object.hpp"
 #include "mrc/utils/type_utils.hpp"
 #include "mrc/version.hpp"
 
 #include <nlohmann/json.hpp>
 #include <rxcpp/rx.hpp>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/cpp/mrc/tests/modules/test_mirror_tap_module.cpp
+++ b/cpp/mrc/tests/modules/test_mirror_tap_module.cpp
@@ -20,10 +20,10 @@
 #include "mrc/cuda/device_guard.hpp"
 #include "mrc/experimental/modules/mirror_tap/mirror_tap.hpp"
 #include "mrc/modules/properties/persistent.hpp"
-#include "mrc/node/operators/broadcast.hpp"
 #include "mrc/node/rx_node.hpp"
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/node/rx_source.hpp"
+#include "mrc/node/rx_source_base.hpp"
 #include "mrc/options/options.hpp"
 #include "mrc/options/topology.hpp"
 #include "mrc/pipeline/executor.hpp"
@@ -38,11 +38,9 @@
 #include <rxcpp/rx.hpp>
 
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 using namespace mrc;
 

--- a/cpp/mrc/tests/modules/test_mirror_tap_orchestrator.cpp
+++ b/cpp/mrc/tests/modules/test_mirror_tap_orchestrator.cpp
@@ -20,9 +20,10 @@
 #include "mrc/cuda/device_guard.hpp"
 #include "mrc/experimental/modules/mirror_tap/mirror_tap_orchestrator.hpp"
 #include "mrc/modules/properties/persistent.hpp"
-#include "mrc/node/operators/broadcast.hpp"
 #include "mrc/node/rx_sink.hpp"
+#include "mrc/node/rx_sink_base.hpp"
 #include "mrc/node/rx_source.hpp"
+#include "mrc/node/rx_source_base.hpp"
 #include "mrc/options/options.hpp"
 #include "mrc/options/topology.hpp"
 #include "mrc/pipeline/executor.hpp"
@@ -37,12 +38,10 @@
 #include <nlohmann/json.hpp>
 #include <rxcpp/rx.hpp>
 
-#include <map>
 #include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
-#include <vector>
 
 using namespace mrc;
 

--- a/cpp/mrc/tests/modules/test_module_util.cpp
+++ b/cpp/mrc/tests/modules/test_module_util.cpp
@@ -20,13 +20,11 @@
 #include "mrc/modules/module_registry_util.hpp"
 #include "mrc/modules/properties/persistent.hpp"
 #include "mrc/modules/sample_modules.hpp"
-#include "mrc/node/rx_source.hpp"
 #include "mrc/version.hpp"
 
 #include <gtest/gtest.h>
+#include <rxcpp/rx.hpp>
 
-#include <map>
-#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/cpp/mrc/tests/test_channel.cpp
+++ b/cpp/mrc/tests/test_channel.cpp
@@ -27,7 +27,6 @@
 
 #include <boost/fiber/buffered_channel.hpp>
 #include <boost/fiber/channel_op_status.hpp>
-#include <boost/fiber/future/future.hpp>
 #include <boost/fiber/operations.hpp>  // for sleep_for
 
 #include <chrono>      // for duration, system_clock, milliseconds, time_point
@@ -35,7 +34,6 @@
 #include <cstdint>     // for uint64_t
 #include <functional>  // for ref, reference_wrapper
 #include <memory>
-#include <string>
 #include <utility>
 // IWYU thinks algorithm is needed for: auto channel = std::make_shared<RecentChannel<int>>(2);
 // IWYU pragma: no_include <algorithm>

--- a/cpp/mrc/tests/test_executor.cpp
+++ b/cpp/mrc/tests/test_executor.cpp
@@ -17,7 +17,9 @@
 
 #include "mrc/node/rx_node.hpp"
 #include "mrc/node/rx_sink.hpp"
+#include "mrc/node/rx_sink_base.hpp"
 #include "mrc/node/rx_source.hpp"
+#include "mrc/node/rx_source_base.hpp"
 #include "mrc/options/engine_groups.hpp"
 #include "mrc/options/options.hpp"
 #include "mrc/options/topology.hpp"
@@ -41,7 +43,6 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <ostream>
@@ -49,7 +50,6 @@
 #include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 
 namespace mrc {
 

--- a/cpp/mrc/tests/test_node.cpp
+++ b/cpp/mrc/tests/test_node.cpp
@@ -40,7 +40,6 @@
 #include <chrono>
 #include <cstddef>
 #include <exception>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <set>

--- a/cpp/mrc/tests/test_pipeline.cpp
+++ b/cpp/mrc/tests/test_pipeline.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "mrc/node/rx_sink.hpp"
+#include "mrc/node/rx_sink_base.hpp"
 #include "mrc/node/rx_source.hpp"
+#include "mrc/node/rx_source_base.hpp"
 #include "mrc/options/options.hpp"
 #include "mrc/options/topology.hpp"
 #include "mrc/pipeline/executor.hpp"
@@ -33,12 +35,9 @@
 
 #include <atomic>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <ostream>
-#include <string>
 #include <utility>
-#include <vector>
 
 namespace mrc {
 

--- a/cpp/mrc/tests/test_segment.cpp
+++ b/cpp/mrc/tests/test_segment.cpp
@@ -23,7 +23,6 @@
 #include "mrc/node/rx_node.hpp"
 #include "mrc/node/rx_sink.hpp"
 #include "mrc/node/rx_source.hpp"
-#include "mrc/node/rx_source_base.hpp"
 #include "mrc/options/options.hpp"
 #include "mrc/options/topology.hpp"
 #include "mrc/pipeline/executor.hpp"
@@ -40,9 +39,7 @@
 
 #include <array>
 #include <atomic>
-#include <future>
 #include <iostream>
-#include <map>
 #include <mutex>
 #include <string>
 #include <utility>

--- a/cpp/mrc/tests/test_thread.cpp
+++ b/cpp/mrc/tests/test_thread.cpp
@@ -25,7 +25,6 @@
 
 #include <coroutine>
 #include <string>
-#include <type_traits>
 
 using namespace mrc;
 


### PR DESCRIPTION
This PR is related to the Morpheus Sherlock work which uses coroutines. Much of this code was pulled from this branch https://github.com/ryanolson/srf/tree/runnable_next and was in a pretty good state. A few minor tweaks and changes have been added.