### PR TITLE
Update `dependencies.yaml` to include `cuda-python`

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -11,11 +11,11 @@ files:
       - cudatoolkit
 
 channels:
+  - conda-forge
   - rapidsai
   - nvidia/label/cuda-11.8.0
   - nvidia
   - rapidsai-nightly
-  - conda-forge
 
 dependencies:
 
@@ -31,21 +31,21 @@ dependencies:
         packages:
           - boost-cpp=1.82
           - ccache
-          - cmake=3.24
+          - cmake=3.25
           - cuda-nvcc
           - cxx-compiler
           - glog=0.6
+          - gtest=1.13
           - gxx=11.2
           - libgrpc=1.54.0
           - libhwloc=2.9.2
           - librmm=23.06
           - ninja=1.10
-          - ucx=1.14
           - nlohmann_json=3.9
-          - gtest=1.13
-          - scikit-build>=0.17
           - pybind11-stubgen=0.10
           - python=3.10
+          - scikit-build>=0.17
+          - ucx=1.14
   cudatoolkit:
     specific:
       - output_types: [conda]
@@ -54,7 +54,8 @@ dependencies:
               cuda: "11.8"
             packages:
               - cuda-cudart-dev=11.8
-              - cuda-nvrtc-dev=11.8
-              - cuda-version=11.8
               - cuda-nvml-dev=11.8
+              - cuda-nvrtc-dev=11.8
+              - cuda-python=11.8.2
               - cuda-tools=11.8
+              - cuda-version=11.8


### PR DESCRIPTION
Update `dependencies.yaml` to include `cuda-python`, as without it we include 12.8.3, which is fails to build for Morpheus.