### PR TITLE
Unifying cmake exports name across all Morpheus repos

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -61,6 +61,7 @@ env:
   GH_TOKEN: "${{ github.token }}"
   GIT_COMMIT: "${{ github.sha }}"
   MRC_ROOT: "${{ github.workspace }}/mrc"
+  RAPIDS_CONDA_RETRY_MAX: "5"
   WORKSPACE: "${{ github.workspace }}/mrc"
   WORKSPACE_TMP: "${{ github.workspace }}/tmp"
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -24,8 +24,8 @@ morpheus_utils_initialize_cpm(MRC_CACHE_DIR)
 # Start with CUDA. Need to add it to our export set
 rapids_find_package(CUDAToolkit
   REQUIRED
-  BUILD_EXPORT_SET ${PROJECT_NAME}-core-exports
-  INSTALL_EXPORT_SET ${PROJECT_NAME}-core-exports
+  BUILD_EXPORT_SET ${PROJECT_NAME}-exports
+  INSTALL_EXPORT_SET ${PROJECT_NAME}-exports
 )
 
 # Boost
@@ -48,8 +48,8 @@ morpheus_utils_configure_rmm()
 # ======
 rapids_find_package(gflags REQUIRED
   GLOBAL_TARGETS gflags
-  BUILD_EXPORT_SET ${PROJECT_NAME}-core-exports
-  INSTALL_EXPORT_SET ${PROJECT_NAME}-core-exports
+  BUILD_EXPORT_SET ${PROJECT_NAME}-exports
+  INSTALL_EXPORT_SET ${PROJECT_NAME}-exports
 )
 
 # glog
@@ -72,8 +72,8 @@ rapids_find_package(gRPC REQUIRED
   gRPC::address_sorting gRPC::gpr gRPC::grpc gRPC::grpc_unsecure gRPC::grpc++ gRPC::grpc++_alts gRPC::grpc++_error_details gRPC::grpc++_reflection
   gRPC::grpc++_unsecure gRPC::grpc_plugin_support gRPC::grpcpp_channelz gRPC::upb gRPC::grpc_cpp_plugin gRPC::grpc_csharp_plugin gRPC::grpc_node_plugin
   gRPC::grpc_objective_c_plugin gRPC::grpc_php_plugin gRPC::grpc_python_plugin gRPC::grpc_ruby_plugin
-  BUILD_EXPORT_SET ${PROJECT_NAME}-core-exports
-  INSTALL_EXPORT_SET ${PROJECT_NAME}-core-exports
+  BUILD_EXPORT_SET ${PROJECT_NAME}-exports
+  INSTALL_EXPORT_SET ${PROJECT_NAME}-exports
 )
 
 # RxCpp
@@ -84,8 +84,8 @@ morpheus_utils_configure_rxcpp()
 # ======
 rapids_find_package(nlohmann_json REQUIRED
   GLOBAL_TARGETS nlohmann_json::nlohmann_json
-  BUILD_EXPORT_SET ${PROJECT_NAME}-core-exports
-  INSTALL_EXPORT_SET ${PROJECT_NAME}-core-exports
+  BUILD_EXPORT_SET ${PROJECT_NAME}-exports
+  INSTALL_EXPORT_SET ${PROJECT_NAME}-exports
   FIND_ARGS
   CONFIG
 )
@@ -103,7 +103,7 @@ if(MRC_BUILD_BENCHMARKS)
   # ================
   rapids_find_package(benchmark REQUIRED
     GLOBAL_TARGETS benchmark::benchmark
-    BUILD_EXPORT_SET ${PROJECT_NAME}-core-exports
+    BUILD_EXPORT_SET ${PROJECT_NAME}-exports
 
     # No install set
     FIND_ARGS
@@ -116,7 +116,7 @@ if(MRC_BUILD_TESTS)
   # ===========
   rapids_find_package(GTest REQUIRED
     GLOBAL_TARGETS GTest::gtest GTest::gmock GTest::gtest_main GTest::gmock_main
-    BUILD_EXPORT_SET ${PROJECT_NAME}-core-exports
+    BUILD_EXPORT_SET ${PROJECT_NAME}-exports
 
     # No install set
     FIND_ARGS

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/CMakeLists.txt
+++ b/cpp/mrc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/CMakeLists.txt
+++ b/cpp/mrc/CMakeLists.txt
@@ -212,7 +212,7 @@ include(GNUInstallDirs)
 install(
   TARGETS libmrc
   DESTINATION ${lib_dir}
-  EXPORT ${PROJECT_NAME}-core-exports
+  EXPORT ${PROJECT_NAME}-exports
   COMPONENT Core
 )
 
@@ -250,7 +250,7 @@ set(rapids_project_version_compat SameMinorVersion)
 # Need to explicitly set VERSION ${PROJECT_VERSION} here since rapids_cmake gets
 # confused with the `RAPIDS_VERSION` variable we use
 rapids_export(INSTALL ${PROJECT_NAME}
-  EXPORT_SET ${PROJECT_NAME}-core-exports
+  EXPORT_SET ${PROJECT_NAME}-exports
   GLOBAL_TARGETS libmrc
   VERSION ${PROJECT_VERSION}
   NAMESPACE mrc::
@@ -261,7 +261,7 @@ rapids_export(INSTALL ${PROJECT_NAME}
 # ##################################################################################################
 # - build export ----------------------------------------------------------------------------------
 rapids_export(BUILD ${PROJECT_NAME}
-  EXPORT_SET ${PROJECT_NAME}-core-exports
+  EXPORT_SET ${PROJECT_NAME}-exports
   GLOBAL_TARGETS libmrc
   VERSION ${PROJECT_VERSION}
   LANGUAGES C CXX CUDA

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/ex00_wrap_data_objects/CMakeLists.txt
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/ex00_wrap_data_objects/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mrc_quickstart_add_pybind11_module(
+mrc_add_pybind11_module(
   data
   MODULE_ROOT
     ${QUICKSTART_HYBRID_HOME}

--- a/docs/quickstart/hybrid/mrc_qs_hybrid/ex01_wrap_nodes/CMakeLists.txt
+++ b/docs/quickstart/hybrid/mrc_qs_hybrid/ex01_wrap_nodes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mrc_quickstart_add_pybind11_module(
+mrc_add_pybind11_module(
   nodes
   MODULE_ROOT
     ${QUICKSTART_HYBRID_HOME}

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -93,7 +93,7 @@ add_dependencies(${PROJECT_NAME}_style_checks mrc_protos-headers-target)
 
 install(
   TARGETS mrc_protos mrc_architect_protos
-  EXPORT ${PROJECT_NAME}-core-exports
+  EXPORT ${PROJECT_NAME}-exports
   PUBLIC_HEADER
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/protos"
 )

--- a/python/mrc/_pymrc/CMakeLists.txt
+++ b/python/mrc/_pymrc/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/python/mrc/_pymrc/CMakeLists.txt
+++ b/python/mrc/_pymrc/CMakeLists.txt
@@ -73,7 +73,7 @@ rapids_cmake_install_lib_dir(lib_dir)
 install(
   TARGETS pymrc
   DESTINATION ${lib_dir}
-  EXPORT ${PROJECT_NAME}-core-exports
+  EXPORT ${PROJECT_NAME}-exports
   COMPONENT Python
 )
 


### PR DESCRIPTION
This PR fixes an issue where some libraries were using `${PROJECT_NAME}-core-exports` and others were using `${PROJECT_NAME}-exports`. Since there is no need for multiple export sets anymore, this updates all exports to be `${PROJECT_NAME}-exports`

Requires https://github.com/nv-morpheus/utilities/pull/61 to be merged first
