### PR TITLE
Remove redundant copy of libmrc_pymrc.so

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -61,6 +61,7 @@ env:
   GH_TOKEN: "${{ github.token }}"
   GIT_COMMIT: "${{ github.sha }}"
   MRC_ROOT: "${{ github.workspace }}/mrc"
+  RAPIDS_CONDA_RETRY_MAX: "5"
   WORKSPACE: "${{ github.workspace }}/mrc"
   WORKSPACE_TMP: "${{ github.workspace }}/tmp"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,19 +26,30 @@ ARG PYTHON_VER=3.10
 FROM ${FROM_IMAGE}:cuda11.8.0-ubuntu20.04-py3.10 AS base
 
 ARG PROJ_NAME=mrc
+ARG USERNAME=morpheus
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
 
 SHELL ["/bin/bash",  "-c"]
 
 RUN --mount=type=cache,target=/var/cache/apt \
     apt update &&\
     apt install --no-install-recommends -y \
-    libnuma1 && \
+    libnuma1 \
+    sudo && \
     rm -rf /var/lib/apt/lists/*
+
+# create a user inside the container
+RUN useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    usermod --shell /bin/bash $USERNAME && \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
 
 COPY ./conda/environments/all_cuda-118_arch-x86_64.yaml /opt/mrc/conda/environments/all_cuda-118_arch-x86_64.yaml
 
 RUN --mount=type=cache,target=/opt/conda/pkgs,sharing=locked \
     echo "create env: ${PROJ_NAME}" && \
+    sudo -g conda -u $USERNAME \
     CONDA_ALWAYS_YES=true \
     /opt/conda/bin/mamba env create -q -n ${PROJ_NAME} --file /opt/mrc/conda/environments/all_cuda-118_arch-x86_64.yaml && \
     chmod -R a+rwX /opt/conda && \
@@ -46,7 +57,8 @@ RUN --mount=type=cache,target=/opt/conda/pkgs,sharing=locked \
 
 RUN /opt/conda/bin/conda init --system &&\
     sed -i 's/xterm-color)/xterm-color|*-256color)/g' ~/.bashrc &&\
-    echo "conda activate ${PROJ_NAME}" >> ~/.bashrc
+    echo "conda activate ${PROJ_NAME}" >> ~/.bashrc && \
+    cp /root/.bashrc /home/$USERNAME/.bashrc
 
 # disable sscache wrappers around compilers
 ENV CMAKE_CUDA_COMPILER_LAUNCHER=
@@ -76,7 +88,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
     less \
     openssh-client \
     psmisc \
-    sudo \
     vim-tiny \
     && \
     rm -rf /var/lib/apt/lists/*
@@ -90,17 +101,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
     apt-get install --no-install-recommends -y dotnet-sdk-6.0 &&\
     rm -rf /var/lib/apt/lists/*
-
-# create a user inside the container
-ARG USERNAME=morpheus
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
-    usermod --shell /bin/bash $USERNAME && \
-    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
-    chmod 0440 /etc/sudoers.d/$USERNAME && \
-    cp /root/.bashrc /home/$USERNAME/.bashrc
 
 USER $USERNAME
 

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,5 +1,7 @@
 include versioneer.py
 include mrc/_version.py
 recursive-include mrc py.typed *.pyi
+recursive-include mrc/_pymrc/tests *.so
 recursive-include mrc/benchmarking *.so
 recursive-include mrc/core *.so
+recursive-include mrc/tests *.so

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,3 +1,5 @@
 include versioneer.py
 include mrc/_version.py
-recursive-include mrc *.so py.typed *.pyi
+recursive-include mrc py.typed *.pyi
+recursive-include mrc/benchmarking *.so
+recursive-include mrc/core *.so

--- a/python/setup.py
+++ b/python/setup.py
@@ -22,20 +22,16 @@ import versioneer
 ##############################################################################
 # - Python package generation ------------------------------------------------
 
-setup(
-    name="mrc",
-    description="mrc",
-    version=versioneer.get_version(),
-    classifiers=[
-        "Intended Audience :: Developers", "Programming Language :: Python", "Programming Language :: Python :: 3.10"
-    ],
-    author="NVIDIA Corporation",
-    setup_requires=[],
-    include_package_data=True,
-    packages=find_namespace_packages(include=["mrc*"], exclude=["tests", "mrc.core.segment.module_definitions"]),
-    package_data={
-        "mrc": ["_pymrc/*.so"]  # Add the pymrc library for the root package
-    },
-    license="Apache",
-    cmdclass=versioneer.get_cmdclass(),
-    zip_safe=False)
+setup(name="mrc",
+      description="mrc",
+      version=versioneer.get_version(),
+      classifiers=[
+          "Intended Audience :: Developers", "Programming Language :: Python", "Programming Language :: Python :: 3.10"
+      ],
+      author="NVIDIA Corporation",
+      setup_requires=[],
+      include_package_data=True,
+      packages=find_namespace_packages(include=["mrc*"], exclude=["tests", "mrc.core.segment.module_definitions"]),
+      license="Apache",
+      cmdclass=versioneer.get_cmdclass(),
+      zip_safe=False)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description
* Prevent `libmrc_pymrc.so` from being installed into python's site-packages dir, as this lib is already present in the lib dir.
* Fixes permissions issue where the conda env was owned by `root:root`, simply ensuring the env retains the `conda` group permission wasn't sufficient as `cmake` attempts to modify exiting dirs (https://gitlab.kitware.com/cmake/cmake/-/issues/10978), and running `chmod -R` after the fact is too slow.

Closes #428

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
