### PR TITLE
Update Conda channels to prioritize `conda-forge` over `nvidia`

### DIFF
--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -98,9 +98,8 @@ if hasArg quick; then
    CONDA_ARGS_ARRAY+=("--variants" "{rapids_version: 24.02}")
 fi
 
-CONDA_ARGS_ARRAY+=("--keep-old-work")
-# And default channels
-CONDA_ARGS_ARRAY+=("-c" "conda-forge" "-c" "rapidsai-nightly" "-c" "nvidia")
+# And default channels (should match dependencies.yaml)
+CONDA_ARGS_ARRAY+=("-c" "conda-forge" "-c" "rapidsai" "-c" "rapidsai-nightly" "-c" "nvidia")
 
 # Set GIT_VERSION to set the project version inside of meta.yaml
 export GIT_VERSION="$(get_version)"

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -3,9 +3,8 @@
 channels:
 - conda-forge
 - rapidsai
-- nvidia/label/cuda-12.1.1
-- nvidia
 - rapidsai-nightly
+- nvidia
 dependencies:
 - bash-completion
 - benchmark=1.8.3

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -3,9 +3,8 @@
 channels:
 - conda-forge
 - rapidsai
-- nvidia/label/cuda-12.1.1
-- nvidia
 - rapidsai-nightly
+- nvidia
 dependencies:
 - benchmark=1.8.3
 - boost-cpp=1.84

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,7 +38,6 @@ files:
     includes:
       - checks
 
-
 channels:
   - conda-forge
   - rapidsai

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -42,9 +42,8 @@ files:
 channels:
   - conda-forge
   - rapidsai
-  - nvidia/label/cuda-12.1.1
-  - nvidia
   - rapidsai-nightly
+  - nvidia
 
 dependencies:
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Closes https://github.com/nv-morpheus/MRC/issues/435
Closes https://github.com/nv-morpheus/MRC/issues/424
Closes https://github.com/nv-morpheus/MRC/issues/423
Closes https://github.com/nv-morpheus/MRC/issues/422

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
