### PR TITLE
Allow memory pressure control in`DataPlaneResources2`

### DIFF
--- a/cmake/Configure_UCXX.cmake
+++ b/cmake/Configure_UCXX.cmake
@@ -34,8 +34,8 @@ function(morpheus_utils_configure_UCXX)
     INSTALL_EXPORT_SET
       ${PROJECT_NAME}-core-exports
     CPM_ARGS
-      GIT_REPOSITORY          https://github.com/pentschev/ucxx.git
-      GIT_TAG                 mrc-all
+      GIT_REPOSITORY          https://github.com/rapidsai/ucxx.git
+      GIT_TAG                 branch-24.06
       GIT_SHALLOW             TRUE
       SOURCE_SUBDIR           cpp
       OPTIONS                 "UCXX_ENABLE_RMM ON"

--- a/cpp/mrc/src/internal/data_plane/data_plane_resources.cpp
+++ b/cpp/mrc/src/internal/data_plane/data_plane_resources.cpp
@@ -391,7 +391,13 @@ uint64_t DataPlaneResources2::register_remote_decriptor(
 {
     auto object_id = get_next_object_id();
     remote_descriptor->encoded_object().set_object_id(object_id);
-    m_remote_descriptor_by_id[object_id] = remote_descriptor;
+    {
+        std::unique_lock lock(m_remote_descriptors_mutex);
+        m_remote_descriptors_cv.wait(lock, [this] {
+            return m_remote_descriptor_by_id.size() < m_max_remote_descriptors;
+        });
+        m_remote_descriptor_by_id[object_id] = remote_descriptor;
+    }
     return object_id;
 }
 
@@ -415,9 +421,18 @@ void DataPlaneResources2::decrement_tokens(remote_descriptor::RemoteDescriptorDe
         remote_descriptor->encoded_object().set_tokens(tokens);
         if (tokens == 0)
         {
-            m_remote_descriptor_by_id.erase(dec_message->object_id);
+            {
+                std::unique_lock lock(m_remote_descriptors_mutex);
+                m_remote_descriptor_by_id.erase(dec_message->object_id);
+            }
+            m_remote_descriptors_cv.notify_one();
         }
     }
+}
+
+void DataPlaneResources2::set_max_remote_descriptors(uint64_t max_remote_descriptors)
+{
+    m_max_remote_descriptors = max_remote_descriptors;
 }
 
 // std::shared_ptr<ucxx::Request> DataPlaneResources2::receive_async2(void* addr,

--- a/cpp/mrc/src/internal/data_plane/data_plane_resources.cpp
+++ b/cpp/mrc/src/internal/data_plane/data_plane_resources.cpp
@@ -433,6 +433,7 @@ void DataPlaneResources2::decrement_tokens(remote_descriptor::RemoteDescriptorDe
 void DataPlaneResources2::set_max_remote_descriptors(uint64_t max_remote_descriptors)
 {
     m_max_remote_descriptors = max_remote_descriptors;
+    m_remote_descriptors_cv.notify_all();
 }
 
 // std::shared_ptr<ucxx::Request> DataPlaneResources2::receive_async2(void* addr,

--- a/cpp/mrc/src/internal/data_plane/data_plane_resources.hpp
+++ b/cpp/mrc/src/internal/data_plane/data_plane_resources.hpp
@@ -35,7 +35,6 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 
@@ -224,8 +223,8 @@ class DataPlaneResources2
     void decrement_tokens(remote_descriptor::RemoteDescriptorDecrementMessage* dec_message);
 
     uint64_t m_max_remote_descriptors{std::numeric_limits<uint64_t>::max()};
-    std::mutex m_remote_descriptors_mutex{};
-    std::condition_variable m_remote_descriptors_cv{};
+    boost::fibers::mutex m_remote_descriptors_mutex{};
+    boost::fibers::condition_variable m_remote_descriptors_cv{};
 
   protected:
     std::map<uint64_t, std::shared_ptr<runtime::RemoteDescriptorImpl2>> m_remote_descriptor_by_id;

--- a/cpp/mrc/src/internal/data_plane/data_plane_resources.hpp
+++ b/cpp/mrc/src/internal/data_plane/data_plane_resources.hpp
@@ -33,7 +33,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -123,6 +125,8 @@ class DataPlaneResources2
     void set_instance_id(uint64_t instance_id);
     bool has_instance_id() const;
     uint64_t get_instance_id() const;
+
+    void set_max_remote_descriptors(uint64_t max_remote_descriptors);
 
     ucxx::Context& context() const;
 
@@ -218,6 +222,10 @@ class DataPlaneResources2
     uint64_t get_next_object_id();
 
     void decrement_tokens(remote_descriptor::RemoteDescriptorDecrementMessage* dec_message);
+
+    uint64_t m_max_remote_descriptors{std::numeric_limits<uint64_t>::max()};
+    std::mutex m_remote_descriptors_mutex{};
+    std::condition_variable m_remote_descriptors_cv{};
 
   protected:
     std::map<uint64_t, std::shared_ptr<runtime::RemoteDescriptorImpl2>> m_remote_descriptor_by_id;

--- a/cpp/mrc/src/tests/test_network.cpp
+++ b/cpp/mrc/src/tests/test_network.cpp
@@ -917,19 +917,15 @@ TEST_F(TestNetwork, TransferFullDescriptorsBroadcast)
         auto recv_data = recv_value_descriptor->value();
 
         EXPECT_EQ(send_data, recv_data);
-
-        // TODO(Peter): Find out why not storing a reference to `recv_value_descriptor` causes a segfault in
-        // `recv_value_descriptor->value()` when called in the next request.
-        return recv_value_descriptor;
     };
 
-    auto recv_value_descriptor1 = processRequest(resources_recv1,
-                                                 endpoint_recv1,
-                                                 endpoint_send1,
-                                                 serialized_data1,
-                                                 std::numeric_limits<uint64_t>::max() - tokens_recv1);
+    processRequest(resources_recv1,
+                   endpoint_recv1,
+                   endpoint_send1,
+                   serialized_data1,
+                   std::numeric_limits<uint64_t>::max() - tokens_recv1);
 
-    auto recv_value_descriptor2 = processRequest(resources_recv2, endpoint_recv2, endpoint_send2, serialized_data2, 0);
+    processRequest(resources_recv2, endpoint_recv2, endpoint_send2, serialized_data2, 0);
 }
 
 // TEST_F(TestNetwork, NetworkEventsManagerLifeCycle)


### PR DESCRIPTION
## Description
Allow memory pressure control in`DataPlaneResources2` via a maximum number of remote descriptors registered and add multithreaded test to verify completion despite blocking behavior of registration thread.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
