### PR TITLE
Update cast_from_pyobject to throw on unsupported types rather than returning null

### DIFF
--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -59,15 +59,7 @@ const std::type_info* cpptype_info_from_object(pybind11::object& obj);
  * @param obj : pybind11 object
  * @return std::string.
  */
-std::string get_py_type_name(const pybind11::object& obj, bool ignore_exceptions = true);
-
-/**
- * @brief Given a pybind11 object, return the Python string representation essentially the same as `str(obj)`
- * @param obj : pybind11 object
- * @param ignore_exceptions : if true, exceptions will be caught and the return value will be an empty string.
- * @return std::string.
- */
-std::string as_string(const pybind11::object& obj, bool ignore_exceptions = true);
+std::string get_py_type_name(const pybind11::object& obj);
 
 void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level = 1);
 

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -54,6 +54,21 @@ void from_import_as(pybind11::module_& dest, const std::string& from, const std:
  */
 const std::type_info* cpptype_info_from_object(pybind11::object& obj);
 
+/**
+ * @brief Given a pybind11 object, return the Python type name essentially the same as `str(type(obj))`
+ * @param obj : pybind11 object
+ * @return std::string.
+ */
+std::string get_py_type_name(const pybind11::object& obj, bool ignore_exceptions = true);
+
+/**
+ * @brief Given a pybind11 object, return the Python string representation essentially the same as `str(obj)`
+ * @param obj : pybind11 object
+ * @param ignore_exceptions : if true, exceptions will be caught and the return value will be an empty string.
+ * @return std::string.
+ */
+std::string as_string(const pybind11::object& obj, bool ignore_exceptions = true);
+
 void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level = 1);
 
 #pragma GCC visibility pop

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -76,37 +76,16 @@ const std::type_info* cpptype_info_from_object(py::object& obj)
     return nullptr;
 }
 
-std::string get_py_type_name(const pybind11::object& obj, bool ignore_exceptions)
+std::string get_py_type_name(const pybind11::object& obj)
 {
-    try
+    if (!obj)
     {
-        const auto py_type = py::type::of(obj);
-        return py_type.attr("__name__").cast<std::string>();
-    } catch (...)
-    {
-        if (!ignore_exceptions)
-        {
-            throw;
-        }
+        // calling py::type::of on a null object will trigger an abort
+        return "";
     }
 
-    return "";
-}
-
-std::string as_string(const pybind11::object& obj, bool ignore_exceptions)
-{
-    try
-    {
-        return py::str(obj).cast<std::string>();
-    } catch (...)
-    {
-        if (!ignore_exceptions)
-        {
-            throw;
-        }
-    }
-
-    return "";
+    const auto py_type = py::type::of(obj);
+    return py_type.attr("__name__").cast<std::string>();
 }
 
 py::object cast_from_json(const json& source)
@@ -219,7 +198,7 @@ json cast_from_pyobject_impl(const py::object& source, const std::string& parent
             path = "/";
         }
 
-        error_message << "Object (" << as_string(source, true) << ") of type: " << get_py_type_name(source, true)
+        error_message << "Object (" << py::str(source).cast<std::string>() << ") of type: " << get_py_type_name(source)
                       << " at path: " << path << " is not JSON serializable";
 
         DVLOG(5) << error_message.str();

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -17,6 +17,8 @@
 
 #include "pymrc/utils.hpp"
 
+#include "pymrc/utilities/acquire_gil.hpp"
+
 #include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/detail/internals.h>
@@ -170,8 +172,11 @@ json cast_from_pyobject(const py::object& source)
         return json(py::cast<std::string>(source));
     }
 
-    // else unsupported return null
-    return json();
+    // else unsupported return throw a type error
+    {
+        AcquireGIL gil;
+        throw py::type_error("Object is not JSON serializable");
+    }
     // NOLINTEND(modernize-return-braced-init-list)
 }
 

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -34,7 +34,6 @@
 #include <climits>
 #include <map>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -158,6 +157,17 @@ TEST_F(TestUtils, CastFromPyObjectSerializeErrors)
     // Test with object in a nested dict
     py::dict d("a"_a = py::dict("b"_a = py::dict("c"_a = py::dict("d"_a = o))), "other"_a = 2);
     EXPECT_THROW(pymrc::cast_from_pyobject(d), py::type_error);
+}
+
+TEST_F(TestUtils, GetTypeName)
+{
+    // invalid objects should return an empty string
+    EXPECT_EQ(pymrc::get_py_type_name(py::object()), "");
+    EXPECT_EQ(pymrc::get_py_type_name(py::none()), "NoneType");
+
+    py::object Decimal = py::module_::import("decimal").attr("Decimal");
+    py::object o       = Decimal("1.0");
+    EXPECT_EQ(pymrc::get_py_type_name(o), "Decimal");
 }
 
 TEST_F(TestUtils, PyObjectWrapper)


### PR DESCRIPTION
## Description
* Currently when `cast_from_pyobject` encounters an unsupported type it returns a json null.
* Updates the method to throw a `pybind11::type_error`, matching the `TypeError` exception raised by the Python std `json.dumps` method.
* Add `get_py_type_name` helper method
* Breaking behavior change

Closes #450 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
