### PR TITLE
Add JSONValues container for holding Python values as JSON objects if possible, and as pybind11::object otherwise

### DIFF
--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -90,12 +90,12 @@ outputs:
         - libgrpc =1.59
         - libhwloc =2.9.2
         - librmm {{ rapids_version }}
-        - nlohmann_json =3.9
+        - nlohmann_json =3.11
         - ucx =1.15
       run:
         # Manually add any packages necessary for run that do not have run_exports. Keep sorted!
         - cuda-version {{ cuda_version }}.*
-        - nlohmann_json =3.9
+        - nlohmann_json =3.11
         - ucx =1.15
         - cuda-cudart
         - boost-cpp =1.84

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - gtest =1.14
     - libhwloc =2.9.2
     - librmm {{ rapids_version }}
-    - nlohmann_json =3.9
+    - nlohmann_json =3.11
     - pybind11-abi # See: https://conda-forge.org/docs/maintainer/knowledge_base.html#pybind11-abi-constraints
     - pybind11-stubgen =0.10
     - python {{ python }}

--- a/ci/iwyu/mappings.imp
+++ b/ci/iwyu/mappings.imp
@@ -11,6 +11,7 @@
 
 # boost
 { "include": ["@<boost/fiber/future/detail/.*>", "private", "<boost/fiber/future/future.hpp>", "public"] },
+{ "include": ["@<boost/algorithm/string/detail/.*>", "private", "<boost/algorithm/string.hpp>",  "public"] },
 
 # cuda
 { "include": ["<cuda_runtime_api.h>", "private", "<cuda_runtime.h>", "public"] },
@@ -33,6 +34,7 @@
 { "symbol": ["@grpc::.*", "private", "<grpcpp/grpcpp.h>", "public"] },
 
 # nlohmann json
+{ "include": ["<nlohmann/json_fwd.hpp>", "public", "<nlohmann/json.hpp>", "public"] },
 { "include": ["<nlohmann/detail/iterators/iter_impl.hpp>", "private", "<nlohmann/json.hpp>", "public"] },
 { "include": ["<nlohmann/detail/iterators/iteration_proxy.hpp>", "private", "<nlohmann/json.hpp>", "public"] },
 { "include": ["<nlohmann/detail/json_ref.hpp>", "private", "<nlohmann/json.hpp>", "public"] },

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - libxml2=2.11.6
 - llvmdev=16
 - ninja=1.11
-- nlohmann_json=3.9
+- nlohmann_json=3.11
 - numactl-libs-cos7-x86_64
 - numpy=1.24
 - pkg-config=0.29

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -29,7 +29,7 @@ dependencies:
 - librmm=24.02
 - libxml2=2.11.6
 - ninja=1.11
-- nlohmann_json=3.9
+- nlohmann_json=3.11
 - numactl-libs-cos7-x86_64
 - pkg-config=0.29
 - pre-commit

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -63,7 +63,7 @@ dependencies:
           - librmm=24.02
           - libxml2=2.11.6 # 2.12 has a bug preventing round-trip serialization in hwloc
           - ninja=1.11
-          - nlohmann_json=3.9
+          - nlohmann_json=3.11
           - numactl-libs-cos7-x86_64
           - pkg-config=0.29
           - pybind11-stubgen=0.10

--- a/python/mrc/_pymrc/CMakeLists.txt
+++ b/python/mrc/_pymrc/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(pymrc
   src/utilities/acquire_gil.cpp
   src/utilities/deserializers.cpp
   src/utilities/function_wrappers.cpp
+  src/utilities/json_values.cpp
   src/utilities/object_cache.cpp
   src/utilities/object_wrappers.cpp
   src/utilities/serializers.cpp

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -21,6 +21,7 @@
 
 #include "mrc/segment/object.hpp"
 
+#include <nlohmann/json_fwd.hpp>
 #include <rxcpp/rx.hpp>
 
 #include <functional>
@@ -40,5 +41,15 @@ using PyObjectOperateFn  = std::function<PyObjectObservable(PyObjectObservable s
 // NOLINTEND(readability-identifier-naming)
 
 using python_map_t = std::map<std::string, pybind11::object>;
+
+/**
+ * @brief Unserializable handler function type, invoked by `cast_from_pyobject` when an object cannot be serialized to
+ * JSON. Implementations should return a valid json object, or throw an exception if the object cannot be serialized.
+ * @param source : pybind11 object
+ * @param path : string json path to object
+ * @return nlohmann::json.
+ */
+using unserializable_handler_fn_t =
+    std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
 
 }  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -29,7 +29,6 @@
 #include <string>
 
 namespace mrc::pymrc {
-#pragma GCC visibility push(default)
 
 // NOLINTBEGIN(readability-identifier-naming)
 using PyHolder           = PyObjectHolder;
@@ -53,5 +52,4 @@ using python_map_t = std::map<std::string, pybind11::object>;
 using unserializable_handler_fn_t =
     std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
 
-#pragma GCC visibility pop
 }  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -24,7 +24,7 @@
 #include <nlohmann/json_fwd.hpp>
 #include <rxcpp/rx.hpp>
 
-#include <functional>
+#include <functional>  // for function
 #include <map>
 #include <string>
 

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -24,6 +24,8 @@
 #include <rxcpp/rx.hpp>
 
 #include <functional>
+#include <map>
+#include <string>
 
 namespace mrc::pymrc {
 
@@ -36,5 +38,7 @@ using PyObjectObservable = rxcpp::observable<PyHolder>;
 using PyNode             = mrc::segment::ObjectProperties;
 using PyObjectOperateFn  = std::function<PyObjectObservable(PyObjectObservable source)>;
 // NOLINTEND(readability-identifier-naming)
+
+using python_map_t = std::map<std::string, pybind11::object>;
 
 }  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -29,6 +29,7 @@
 #include <string>
 
 namespace mrc::pymrc {
+#pragma GCC visibility push(default)
 
 // NOLINTBEGIN(readability-identifier-naming)
 using PyHolder           = PyObjectHolder;
@@ -52,4 +53,5 @@ using python_map_t = std::map<std::string, pybind11::object>;
 using unserializable_handler_fn_t =
     std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
 
+#pragma GCC visibility pop
 }  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -56,14 +56,12 @@ class PYBIND11_EXPORT JSONValues
 
     pybind11::object to_python() const;
     nlohmann::json::const_reference to_json() const;
-    nlohmann::json to_json();
 
     pybind11::object get_python(const std::string& path) const;
     nlohmann::json get_json(const std::string& path) const;
 
   private:
     nlohmann::json unserializable_handler(const pybind11::object& obj, const std::string& path);
-    void ensure_json_serializable() const;
 
     nlohmann::json m_serialized_values;
     std::map<std::string, pybind11::object> m_py_objects;

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -49,6 +49,7 @@ class PYBIND11_EXPORT JSONValues
     JSONValues& operator=(const JSONValues& other) = default;
     JSONValues& operator=(JSONValues&& other)      = default;
 
+    // TODO: Docstrings
     JSONValues set_value(const std::string& path, const pybind11::object& value) const;
     JSONValues set_value(const std::string& path, nlohmann::json value) const;
     JSONValues set_value(const std::string& path, const JSONValues& value) const;
@@ -57,10 +58,16 @@ class PYBIND11_EXPORT JSONValues
     bool has_unserializable() const;
 
     pybind11::object to_python() const;
-    nlohmann::json::const_reference to_json() const;
+
+    nlohmann::json::const_reference view_json() const;
+
+    nlohmann::json to_json(unserializable_handler_fn_t unserializable_handler_fn = nullptr) const;
+
+    static nlohmann::json stringify(const pybind11::object& obj, const std::string& path);
 
     pybind11::object get_python(const std::string& path) const;
-    nlohmann::json::const_reference get_json(const std::string& path) const;
+    nlohmann::json get_json(const std::string& path,
+                            unserializable_handler_fn_t unserializable_handler_fn = nullptr) const;
 
     JSONValues operator[](const std::string& path) const;
 

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -37,12 +37,20 @@ class PYBIND11_EXPORT JSONValues
   public:
     JSONValues() = delete;
     JSONValues(pybind11::object values);
+    JSONValues(nlohmann::json values);
 
     JSONValues(const JSONValues& other) = default;
     JSONValues(JSONValues&& other)      = default;
     ~JSONValues()                       = default;
 
+    JSONValues set_value(const std::string& path, const pybind11::object& value) const;
+    JSONValues set_value(const std::string& path, nlohmann::json value) const;
+
+    std::size_t num_unserializable() const;
+    bool has_unserializable() const;
+
     pybind11::object to_python() const;
+    nlohmann::json to_json() const;
 
   private:
     nlohmann::json unserializable_handler(const pybind11::object& obj, const std::string& path);

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <pybind11/pytypes.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace mrc::pymrc {
+
+#pragma GCC visibility push(default)
+/**
+ * @brief Immutable container for holding Python values as JSON objects if possible, and as pybind11::object otherwise.
+ * The container can be copied and moved, but the underlying JSON object is immutable.
+ **/
+class PYBIND11_EXPORT JSONValues
+{
+  public:
+    JSONValues() = delete;
+    JSONValues(pybind11::object values);
+
+    JSONValues(const JSONValues& other) = default;
+    JSONValues(JSONValues&& other)      = default;
+    ~JSONValues()                       = default;
+
+    pybind11::object to_python() const;
+
+  private:
+    nlohmann::json unserializable_handler(const pybind11::object& obj, const std::string& path);
+
+    nlohmann::json m_serialized_values;
+    std::map<std::string, pybind11::object> m_py_objects;
+};
+
+#pragma GCC visibility pop
+}  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -17,11 +17,12 @@
 
 #pragma once
 
+#include "pymrc/types.hpp"
+
 #include <nlohmann/json.hpp>
 #include <pybind11/pytypes.h>  // for PYBIND11_EXPORT & pybind11::object
 
 #include <cstddef>  // for size_t
-#include <map>
 #include <string>
 // IWYU wants us to use the pybind11.h for the PYBIND11_EXPORT macro, but we already have it in pytypes.h
 // IWYU pragma: no_include <pybind11/pybind11.h>
@@ -29,6 +30,7 @@
 namespace mrc::pymrc {
 
 #pragma GCC visibility push(default)
+
 /**
  * @brief Immutable container for holding Python values as JSON objects if possible, and as pybind11::object otherwise.
  * The container can be copied and moved, but the underlying JSON object is immutable.
@@ -58,13 +60,16 @@ class PYBIND11_EXPORT JSONValues
     nlohmann::json::const_reference to_json() const;
 
     pybind11::object get_python(const std::string& path) const;
-    nlohmann::json get_json(const std::string& path) const;
+    nlohmann::json::const_reference get_json(const std::string& path) const;
+
+    JSONValues operator[](const std::string& path) const;
 
   private:
+    JSONValues(nlohmann::json&& values, python_map_t&& py_objects);
     nlohmann::json unserializable_handler(const pybind11::object& obj, const std::string& path);
 
     nlohmann::json m_serialized_values;
-    std::map<std::string, pybind11::object> m_py_objects;
+    python_map_t m_py_objects;
 };
 
 #pragma GCC visibility pop

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -20,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <pybind11/pytypes.h>  // for PYBIND11_EXPORT & pybind11::object
 
+#include <cstddef>  // for size_t
 #include <map>
 #include <string>
 // IWYU wants us to use the pybind11.h for the PYBIND11_EXPORT macro, but we already have it in pytypes.h

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -36,7 +36,7 @@ namespace mrc::pymrc {
 class PYBIND11_EXPORT JSONValues
 {
   public:
-    JSONValues() = delete;
+    JSONValues();
     JSONValues(pybind11::object values);
     JSONValues(nlohmann::json values);
 

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -44,6 +44,9 @@ class PYBIND11_EXPORT JSONValues
     JSONValues(JSONValues&& other)      = default;
     ~JSONValues()                       = default;
 
+    JSONValues& operator=(const JSONValues& other) = default;
+    JSONValues& operator=(JSONValues&& other)      = default;
+
     JSONValues set_value(const std::string& path, const pybind11::object& value) const;
     JSONValues set_value(const std::string& path, nlohmann::json value) const;
 

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -49,6 +49,7 @@ class PYBIND11_EXPORT JSONValues
 
     JSONValues set_value(const std::string& path, const pybind11::object& value) const;
     JSONValues set_value(const std::string& path, nlohmann::json value) const;
+    JSONValues set_value(const std::string& path, const JSONValues& value) const;
 
     std::size_t num_unserializable() const;
     bool has_unserializable() const;

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -55,10 +55,15 @@ class PYBIND11_EXPORT JSONValues
     bool has_unserializable() const;
 
     pybind11::object to_python() const;
-    nlohmann::json to_json() const;
+    nlohmann::json::const_reference to_json() const;
+    nlohmann::json to_json();
+
+    pybind11::object get_python(const std::string& path) const;
+    nlohmann::json get_json(const std::string& path) const;
 
   private:
     nlohmann::json unserializable_handler(const pybind11::object& obj, const std::string& path);
+    void ensure_json_serializable() const;
 
     nlohmann::json m_serialized_values;
     std::map<std::string, pybind11::object> m_py_objects;

--- a/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/json_values.hpp
@@ -18,11 +18,12 @@
 #pragma once
 
 #include <nlohmann/json.hpp>
-#include <pybind11/pytypes.h>
+#include <pybind11/pytypes.h>  // for PYBIND11_EXPORT & pybind11::object
 
 #include <map>
-#include <memory>
 #include <string>
+// IWYU wants us to use the pybind11.h for the PYBIND11_EXPORT macro, but we already have it in pytypes.h
+// IWYU pragma: no_include <pybind11/pybind11.h>
 
 namespace mrc::pymrc {
 

--- a/python/mrc/_pymrc/include/pymrc/utilities/object_cache.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utilities/object_cache.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "pymrc/types.hpp"
+
 #include <pybind11/pytypes.h>
 
 #include <cstddef>
@@ -95,7 +97,7 @@ class __attribute__((visibility("default"))) PythonObjectCache
      */
     void atexit_callback();
 
-    std::map<std::string, pybind11::object> m_object_cache;
+    python_map_t m_object_cache;
 };
 
 #pragma GCC visibility pop

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "pymrc/types.hpp"
+
 #include <nlohmann/json_fwd.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -32,16 +34,6 @@ namespace mrc::pymrc {
 #pragma GCC visibility push(default)
 
 pybind11::object cast_from_json(const nlohmann::json& source);
-
-/**
- * @brief Unserializable handler function type, invoked by `cast_from_pyobject` when an object cannot be serialized to
- * JSON. Implementations should return a valid json object, or throw an exception if the object cannot be serialized.
- * @param source : pybind11 object
- * @param path : string json path to object
- * @return nlohmann::json.
- */
-using unserializable_handler_fn_t =
-    std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
 
 /**
  * @brief Convert a pybind11 object to a JSON object. If the object cannot be serialized, a pybind11::type_error

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -31,7 +31,18 @@ namespace mrc::pymrc {
 #pragma GCC visibility push(default)
 
 pybind11::object cast_from_json(const nlohmann::json& source);
-nlohmann::json cast_from_pyobject(const pybind11::object& source);
+
+/**
+ * @brief Unserializable handler function type, invoked by `cast_from_pyobject` when an object cannot be serialized to
+ * JSON. Implementations should return a valid json object, or throw an exception if the object cannot be serialized.
+ * @param source : pybind11 object
+ * @param path : string json path to object
+ * @return nlohmann::json.
+ */
+using unserializable_handler_fn_t =
+    std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
+nlohmann::json cast_from_pyobject(const pybind11::object& source,
+                                  unserializable_handler_fn_t unserializable_handler_fn = nullptr);
 
 void import_module_object(pybind11::module_&, const std::string&, const std::string&);
 void import_module_object(pybind11::module_& dest, const pybind11::module_& mod);

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -59,15 +59,7 @@ const std::type_info* cpptype_info_from_object(pybind11::object& obj);
  * @param obj : pybind11 object
  * @return std::string.
  */
-std::string get_py_type_name(const pybind11::object& obj, bool ignore_exceptions = true);
-
-/**
- * @brief Given a pybind11 object, return the Python string representation essentially the same as `str(obj)`
- * @param obj : pybind11 object
- * @param ignore_exceptions : if true, exceptions will be caught and the return value will be an empty string.
- * @return std::string.
- */
-std::string as_string(const pybind11::object& obj, bool ignore_exceptions = true);
+std::string get_py_type_name(const pybind11::object& obj);
 
 void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level = 1);
 

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -22,6 +22,7 @@
 #include <pybind11/pytypes.h>
 #include <sys/types.h>
 
+#include <functional>  // for function
 #include <string>
 #include <typeinfo>
 

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -42,8 +42,24 @@ pybind11::object cast_from_json(const nlohmann::json& source);
  */
 using unserializable_handler_fn_t =
     std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
+
+/**
+ * @brief Convert a pybind11 object to a JSON object. If the object cannot be serialized, a pybind11::type_error
+ * exception be thrown.
+ * @param source : pybind11 object
+ * @return nlohmann::json.
+ */
+nlohmann::json cast_from_pyobject(const pybind11::object& source);
+
+/**
+ * @brief Convert a pybind11 object to a JSON object. If the object cannot be serialized, the unserializable_handler_fn
+ * will be invoked to handle the object.
+ * @param source : pybind11 object
+ * @param unserializable_handler_fn : unserializable_handler_fn_t
+ * @return nlohmann::json.
+ */
 nlohmann::json cast_from_pyobject(const pybind11::object& source,
-                                  unserializable_handler_fn_t unserializable_handler_fn = nullptr);
+                                  unserializable_handler_fn_t unserializable_handler_fn);
 
 void import_module_object(pybind11::module_&, const std::string&, const std::string&);
 void import_module_object(pybind11::module_& dest, const pybind11::module_& mod);

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -24,7 +24,6 @@
 #include <pybind11/pytypes.h>
 #include <sys/types.h>
 
-#include <functional>  // for function
 #include <string>
 #include <typeinfo>
 

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -54,6 +54,21 @@ void from_import_as(pybind11::module_& dest, const std::string& from, const std:
  */
 const std::type_info* cpptype_info_from_object(pybind11::object& obj);
 
+/**
+ * @brief Given a pybind11 object, return the Python type name essentially the same as `str(type(obj))`
+ * @param obj : pybind11 object
+ * @return std::string.
+ */
+std::string get_py_type_name(const pybind11::object& obj, bool ignore_exceptions = true);
+
+/**
+ * @brief Given a pybind11 object, return the Python string representation essentially the same as `str(obj)`
+ * @param obj : pybind11 object
+ * @param ignore_exceptions : if true, exceptions will be caught and the return value will be an empty string.
+ * @return std::string.
+ */
+std::string as_string(const pybind11::object& obj, bool ignore_exceptions = true);
+
 void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level = 1);
 
 #pragma GCC visibility pop

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -203,6 +203,18 @@ JSONValues JSONValues::set_value(const std::string& path, nlohmann::json value) 
     return set_value(path, py_obj);
 }
 
+JSONValues JSONValues::set_value(const std::string& path, const JSONValues& value) const
+{
+    if (value.has_unserializable())
+    {
+        AcquireGIL gil;
+        py::object py_obj = value.to_python();
+        return set_value(path, py_obj);
+    }
+
+    return set_value(path, value.to_json());
+}
+
 nlohmann::json JSONValues::unserializable_handler(const py::object& obj, const std::string& path)
 {
     /* We don't know how to serialize the Object, throw it into m_py_objects and return a place-holder */

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -243,7 +243,7 @@ nlohmann::json JSONValues::get_json(const std::string& path,
 nlohmann::json JSONValues::stringify(const pybind11::object& obj, const std::string& path)
 {
     AcquireGIL gil;
-    return {py::str(obj).cast<std::string>()};
+    return py::str(obj).cast<std::string>();
 }
 
 JSONValues JSONValues::set_value(const std::string& path, const pybind11::object& value) const

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -27,7 +27,7 @@
 #include <pybind11/cast.h>
 
 #include <iterator>   // for next
-#include <ostream>    // for operator<< needed for logging
+#include <sstream>    // for operator<< & stringstream
 #include <stdexcept>  // for runtime_error
 #include <utility>    // for move
 #include <vector>     // for vector
@@ -170,7 +170,7 @@ py::object JSONValues::to_python() const
     return results;
 }
 
-void JSONValues::ensure_json_serializable() const
+nlohmann::json::const_reference JSONValues::to_json() const
 {
     if (const auto num_unserializable = this->num_unserializable(); num_unserializable > 0)
     {
@@ -183,17 +183,7 @@ void JSONValues::ensure_json_serializable() const
 
         throw std::runtime_error(error_message.str());
     }
-}
 
-nlohmann::json::const_reference JSONValues::to_json() const
-{
-    ensure_json_serializable();
-    return m_serialized_values;
-}
-
-nlohmann::json JSONValues::to_json()
-{
-    ensure_json_serializable();
     return m_serialized_values;
 }
 

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -190,14 +190,10 @@ nlohmann::json::const_reference JSONValues::to_json() const
 pybind11::object JSONValues::get_python(const std::string& path) const
 
 {
+    DCHECK(path[0] == '/');
     AcquireGIL gil;
     auto root_obj = to_python();
-    if (path.empty())
-    {
-        return root_obj;
-    }
-
-    auto found = find_object_at_path(root_obj, path);
+    auto found    = find_object_at_path(root_obj, path);
     if (found.index.is_none())
     {
         return found.obj;
@@ -208,8 +204,9 @@ pybind11::object JSONValues::get_python(const std::string& path) const
 
 nlohmann::json JSONValues::get_json(const std::string& path) const
 {
+    DCHECK(path[0] == '/');
     nlohmann::json::const_reference json = to_json();
-    if (path.empty() || path == "/")
+    if (path == "/")
     {
         return json;
     }

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -26,12 +26,13 @@
 #include <glog/logging.h>
 #include <pybind11/cast.h>
 
-#include <iterator>   // for next
-#include <map>        // for map
-#include <sstream>    // for operator<< & stringstream
-#include <stdexcept>  // for runtime_error
-#include <utility>    // for move
-#include <vector>     // for vector
+#include <functional>  // for function
+#include <iterator>    // for next
+#include <map>         // for map
+#include <sstream>     // for operator<< & stringstream
+#include <stdexcept>   // for runtime_error
+#include <utility>     // for move
+#include <vector>      // for vector
 
 // We already have <boost/algorithm/string.hpp> included we don't need these others, it is also the only public header
 // with a definition for boost::is_any_of, so even if we replaced string.hpp with these others we would still need to

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pymrc/utilities/json_values.hpp"
+
+#include "pymrc/utilities/acquire_gil.hpp"
+#include "pymrc/utils.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <glog/logging.h>
+#include <nlohmann/json_fwd.hpp>
+#include <pybind11/cast.h>
+#include <pybind11/gil.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pylifecycle.h>
+
+#include <cstddef>
+#include <mutex>
+#include <ostream>
+#include <ranges>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace py = pybind11;
+using namespace std::literals;
+
+namespace {
+
+void patch_object(py::object& obj,
+                  std::vector<std::string>::const_iterator path,
+                  std::vector<std::string>::const_iterator path_end,
+                  const py::object& value)
+{
+    if (path == path_end)
+    {
+        obj = value;
+    }
+    else if (py::isinstance<py::dict>(obj))
+    {
+        const auto& key = *path;
+        auto py_dict    = obj.cast<py::dict>();
+        auto entry      = py_dict[key.c_str()];
+        auto next_path  = std::next(path);
+
+        // There are one of two possibilities here:
+        // 1. The path is terminal and we should assign value to the dict
+        // 2. The path is not terminal and we should recurse into the dict
+        if (next_path == path_end)
+        {
+            entry = value;
+        }
+        else
+        {
+            // entry is of type item_accessor, assigning it to a py::object will trigger a __getitem__ call
+            py::object next_obj = entry;
+            patch_object(next_obj, next_path, path_end, value);
+        }
+    }
+    else if (py::isinstance<py::list>(obj))
+    {
+        auto py_list     = obj.cast<py::list>();
+        const auto index = std::stoul(*path);
+        auto next_path   = std::next(path);
+        auto entry       = py_list[index];
+        if (next_path == path_end)
+        {
+            entry = value;
+        }
+        else
+        {
+            py::object next_obj = entry;
+            patch_object(next_obj, next_path, path_end, value);
+        }
+    }
+    else
+    {
+        throw std::runtime_error("Invalid path");
+    }
+}
+}  // namespace
+
+namespace mrc::pymrc {
+JSONValues::JSONValues(py::object values)
+{
+    AcquireGIL gil;
+    m_serialized_values = cast_from_pyobject(values, [this](const py::object& source, const std::string& path) {
+        return this->unserializable_handler(source, path);
+    });
+}
+
+py::object JSONValues::to_python() const
+{
+    AcquireGIL gil;
+    py::object results{cast_from_json(m_serialized_values)};
+    for (const auto& [path, obj] : m_py_objects)
+    {
+        DCHECK(path[0] == '/');
+        DVLOG(10) << "Restoring object at path: " << path;
+        std::vector<std::string> path_parts;
+        boost::split(path_parts, path, boost::is_any_of("/"));
+
+        // Since our paths always begin with a '/', the first element will always be empty in the case where path="/"
+        // path_parts will be {"", ""} and we can skip the first element
+        auto itr = path_parts.cbegin();
+        ++itr;
+    }
+
+    return results;
+}
+
+nlohmann::json JSONValues::unserializable_handler(const py::object& obj, const std::string& path)
+{
+    /* We don't know how to serialize the Object, throw it into m_py_objects and return a reference ID*/
+
+    // Remove constness and cache the object
+    py::object non_const_copy = obj;
+    DVLOG(10) << "Storing unserializable object at path: " << path;
+    m_py_objects[path] = std::move(non_const_copy);
+
+    return {"**pymrc_placeholder"s};
+}
+
+}  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -20,26 +20,25 @@
 #include "pymrc/utilities/acquire_gil.hpp"
 #include "pymrc/utils.hpp"
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string.hpp>  // for split
 #include <glog/logging.h>
-#include <nlohmann/json_fwd.hpp>
 #include <pybind11/cast.h>
-#include <pybind11/gil.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pylifecycle.h>
 
-#include <cstddef>
-#include <mutex>
-#include <ostream>
-#include <ranges>
-#include <stdexcept>
-#include <string_view>
-#include <utility>
-#include <vector>
+#include <iterator>   // for next
+#include <ostream>    // for operator<< needed for logging
+#include <stdexcept>  // for runtime_error
+#include <utility>    // for move
+#include <vector>     // for vector
+
+// We already have <boost/algorithm/string.hpp> included we don't need these others, it is also the only public header
+// with a definition for boost::is_any_of, so even if we replaced string.hpp with these others we would still need to
+// include string.hpp or a detail/ header
+// IWYU pragma: no_include <boost/algorithm/string/classification.hpp>
+// IWYU pragma: no_include <boost/algorithm/string/split.hpp>
+// IWYU pragma: no_include <boost/iterator/iterator_facade.hpp>
 
 namespace py = pybind11;
-using namespace std::literals;
+using namespace std::string_literals;
 
 namespace {
 

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -26,7 +26,6 @@
 
 #include <iterator>   // for next
 #include <ostream>    // for operator<< needed for logging
-#include <sstream>    // for stringstream
 #include <stdexcept>  // for runtime_error
 #include <utility>    // for move
 #include <vector>     // for vector

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -116,6 +116,8 @@ void validate_path(const std::string& path)
 }  // namespace
 
 namespace mrc::pymrc {
+JSONValues::JSONValues() : JSONValues(nlohmann::json()) {}
+
 JSONValues::JSONValues(py::object values)
 {
     AcquireGIL gil;

--- a/python/mrc/_pymrc/src/utilities/json_values.cpp
+++ b/python/mrc/_pymrc/src/utilities/json_values.cpp
@@ -255,7 +255,7 @@ nlohmann::json JSONValues::get_json(const std::string& path,
 nlohmann::json JSONValues::stringify(const pybind11::object& obj, const std::string& path)
 {
     AcquireGIL gil;
-    return {py::str(obj)};
+    return {py::str(obj).cast<std::string>()};
 }
 
 JSONValues JSONValues::set_value(const std::string& path, const pybind11::object& value) const

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -76,37 +76,16 @@ const std::type_info* cpptype_info_from_object(py::object& obj)
     return nullptr;
 }
 
-std::string get_py_type_name(const pybind11::object& obj, bool ignore_exceptions)
+std::string get_py_type_name(const pybind11::object& obj)
 {
-    try
+    if (!obj)
     {
-        const auto py_type = py::type::of(obj);
-        return py_type.attr("__name__").cast<std::string>();
-    } catch (...)
-    {
-        if (!ignore_exceptions)
-        {
-            throw;
-        }
+        // calling py::type::of on a null object will trigger an abort
+        return "";
     }
 
-    return "";
-}
-
-std::string as_string(const pybind11::object& obj, bool ignore_exceptions)
-{
-    try
-    {
-        return py::str(obj).cast<std::string>();
-    } catch (...)
-    {
-        if (!ignore_exceptions)
-        {
-            throw;
-        }
-    }
-
-    return "";
+    const auto py_type = py::type::of(obj);
+    return py_type.attr("__name__").cast<std::string>();
 }
 
 py::object cast_from_json(const json& source)
@@ -219,7 +198,7 @@ json cast_from_pyobject_impl(const py::object& source, const std::string& parent
             path = "/";
         }
 
-        error_message << "Object (" << as_string(source, true) << ") of type: " << get_py_type_name(source, true)
+        error_message << "Object (" << py::str(source).cast<std::string>() << ") of type: " << get_py_type_name(source)
                       << " at path: " << path << " is not JSON serializable";
 
         DVLOG(5) << error_message.str();

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -226,6 +226,11 @@ json cast_from_pyobject(const py::object& source, unserializable_handler_fn_t un
     return cast_from_pyobject_impl(source, unserializable_handler_fn);
 }
 
+json cast_from_pyobject(const py::object& source)
+{
+    return cast_from_pyobject_impl(source, nullptr);
+}
+
 void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level)
 {
     PyErr_WarnEx(PyExc_DeprecationWarning, deprecation_message.c_str(), stack_level);

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -17,6 +17,8 @@
 
 #include "pymrc/utils.hpp"
 
+#include "pymrc/utilities/acquire_gil.hpp"
+
 #include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/detail/internals.h>
@@ -170,8 +172,11 @@ json cast_from_pyobject(const py::object& source)
         return json(py::cast<std::string>(source));
     }
 
-    // else unsupported return null
-    return json();
+    // else unsupported return throw a type error
+    {
+        AcquireGIL gil;
+        throw py::type_error("Object is not JSON serializable");
+    }
     // NOLINTEND(modernize-return-braced-init-list)
 }
 

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -170,7 +170,7 @@ json cast_from_pyobject_impl(const py::object& source,
         for (const auto& p : py_list)
         {
             std::string path{parent_path + "/" + std::to_string(json_arr.size())};
-            json_arr.push_back(cast_from_pyobject_impl(p.cast<py::object>(), unserializable_handler_fn, parent_path));
+            json_arr.push_back(cast_from_pyobject_impl(p.cast<py::object>(), unserializable_handler_fn, path));
         }
 
         return json_arr;

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -17,14 +17,9 @@
 
 #include "pymrc/utils.hpp"
 
-<<<<<<< HEAD
 #include "pymrc/utilities/acquire_gil.hpp"
 
 #include <glog/logging.h>
-    =======
-#include "pymrc/utilities/object_cache.hpp"
-
-    >>>>>>> 1c95d226 (Utils updates)
 #include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/detail/internals.h>
@@ -37,208 +32,207 @@
 #include <string>
 #include <utility>
 
-    namespace mrc::pymrc
+namespace mrc::pymrc {
+namespace py = pybind11;
+
+using nlohmann::json;
+
+void import_module_object(py::module_& dest, const std::string& source, const std::string& member)
 {
-    namespace py = pybind11;
+    dest.attr(member.c_str()) = py::module_::import(source.c_str()).attr(member.c_str());
+}
 
-    using nlohmann::json;
+void import_module_object(py::module_& dest, const py::module_& mod)
+{
+    // Get the module name and save in __dict__
+    auto mod_name               = mod.attr("__name__")().cast<std::string>();
+    dest.attr(mod_name.c_str()) = mod;
+}
 
-    void import_module_object(py::module_ & dest, const std::string& source, const std::string& member)
+void import(pybind11::module_& dest, const std::string& mod)
+{
+    dest.attr(mod.c_str()) = py::module_::import(mod.c_str());
+}
+
+void from_import(pybind11::module_& dest, const std::string& mod, const std::string& attr)
+{
+    from_import_as(dest, mod, attr, attr);
+}
+
+void from_import_as(py::module_& dest, const std::string& from, const std::string& import, const std::string& as)
+{
+    dest.attr(as.c_str()) = py::module_::import(from.c_str()).attr(import.c_str());
+}
+
+const std::type_info* cpptype_info_from_object(py::object& obj)
+{
+    py::detail::type_info* tinfo = py::detail::get_type_info((PyTypeObject*)obj.ptr());
+    if (tinfo != nullptr)
     {
-        dest.attr(member.c_str()) = py::module_::import(source.c_str()).attr(member.c_str());
+        return tinfo->cpptype;
     }
 
-    void import_module_object(py::module_ & dest, const py::module_& mod)
+    return nullptr;
+}
+
+std::string get_py_type_name(const pybind11::object& obj)
+{
+    if (!obj)
     {
-        // Get the module name and save in __dict__
-        auto mod_name               = mod.attr("__name__")().cast<std::string>();
-        dest.attr(mod_name.c_str()) = mod;
+        // calling py::type::of on a null object will trigger an abort
+        return "";
     }
 
-    void import(pybind11::module_ & dest, const std::string& mod)
+    const auto py_type = py::type::of(obj);
+    return py_type.attr("__name__").cast<std::string>();
+}
+
+py::object cast_from_json(const json& source)
+{
+    if (source.is_null())
     {
-        dest.attr(mod.c_str()) = py::module_::import(mod.c_str());
-    }
-
-    void from_import(pybind11::module_ & dest, const std::string& mod, const std::string& attr)
-    {
-        from_import_as(dest, mod, attr, attr);
-    }
-
-    void from_import_as(py::module_ & dest, const std::string& from, const std::string& import, const std::string& as)
-    {
-        dest.attr(as.c_str()) = py::module_::import(from.c_str()).attr(import.c_str());
-    }
-
-    const std::type_info* cpptype_info_from_object(py::object & obj)
-    {
-        py::detail::type_info* tinfo = py::detail::get_type_info((PyTypeObject*)obj.ptr());
-        if (tinfo != nullptr)
-        {
-            return tinfo->cpptype;
-        }
-
-        return nullptr;
-    }
-
-    std::string get_py_type_name(const pybind11::object& obj)
-    {
-        if (!obj)
-        {
-            // calling py::type::of on a null object will trigger an abort
-            return "";
-        }
-
-        const auto py_type = py::type::of(obj);
-        return py_type.attr("__name__").cast<std::string>();
-    }
-
-    py::object cast_from_json(const json& source)
-    {
-        if (source.is_null())
-        {
-            return py::none();
-        }
-        if (source.is_array())
-        {
-            py::list list_;
-            for (const auto& element : source)
-            {
-                list_.append(cast_from_json(element));
-            }
-            return std::move(list_);
-        }
-
-        if (source.is_boolean())
-        {
-            return py::bool_(source.get<bool>());
-        }
-        if (source.is_number_float())
-        {
-            return py::float_(source.get<double>());
-        }
-        if (source.is_number_integer())
-        {
-            return py::int_(source.get<json::number_integer_t>());
-        }
-        if (source.is_number_unsigned())
-        {
-            return py::int_(source.get<json::number_unsigned_t>());  // std::size_t ?
-        }
-        if (source.is_object())
-        {
-            py::dict dict;
-            for (const auto& it : source.items())
-            {
-                dict[py::str(it.key())] = cast_from_json(it.value());
-            }
-
-            return std::move(dict);
-        }
-        if (source.is_string())
-        {
-            return py::str(source.get<std::string>());
-        }
-
         return py::none();
-        // throw std::runtime_error("Unsupported conversion type.");
     }
-
-    json cast_from_pyobject_impl(const py::object& source, const std::string& parent_path = "")
+    if (source.is_array())
     {
-        // Dont return via initializer list with JSON. It performs type deduction and gives different results
-        // NOLINTBEGIN(modernize-return-braced-init-list)
-        if (source.is_none())
+        py::list list_;
+        for (const auto& element : source)
         {
-            return json();
+            list_.append(cast_from_json(element));
         }
-
-        if (py::isinstance<py::dict>(source))
-        {
-            const auto py_dict = source.cast<py::dict>();
-            auto json_obj      = json::object();
-            for (const auto& p : py_dict)
-            {
-                std::string key{p.first.cast<std::string>()};
-                std::string path{parent_path + "/" + key};
-                json_obj[key] = cast_from_pyobject_impl(p.second.cast<py::object>(), path);
-            }
-
-            return json_obj;
-        }
-
-        if (py::isinstance<py::list>(source) || py::isinstance<py::tuple>(source))
-        {
-            const auto py_list = source.cast<py::list>();
-            auto json_arr      = json::array();
-            for (const auto& p : py_list)
-            {
-                json_arr.push_back(cast_from_pyobject_impl(p.cast<py::object>(), parent_path));
-            }
-
-            return json_arr;
-        }
-
-        if (py::isinstance<py::bool_>(source))
-        {
-            return json(py::cast<bool>(source));
-        }
-
-        if (py::isinstance<py::int_>(source))
-        {
-            return json(py::cast<long>(source));
-        }
-
-        if (py::isinstance<py::float_>(source))
-        {
-            return json(py::cast<double>(source));
-        }
-
-        if (py::isinstance<py::str>(source))
-        {
-            return json(py::cast<std::string>(source));
-        }
-
-        // else unsupported return throw a type error
-        // {
-        //     AcquireGIL gil;
-        //     std::ostringstream error_message;
-        //     std::string path{parent_path};
-        //     if (path.empty())
-        //     {
-        //         path = "/";
-        //     }
-
-        //     error_message << "Object (" << py::str(source).cast<std::string>() << ") of type: " <<
-        //     get_py_type_name(source)
-        //                   << " at path: " << path << " is not JSON serializable";
-
-        //     DVLOG(5) << error_message.str();
-        //     throw py::type_error(error_message.str());
-        // }
-
-        /* We don't know how to serialize the Object, throw it into cache and return a reference ID*/
-        // Use Python's uuid module to generate a UUID
-        py::object uuid_module = py::module_::import("uuid");
-        py::object uuid_obj    = uuid_module.attr("uuid4")();
-        std::string uuid_str   = py::str(uuid_obj);
-
-        // Remove constness and cache the object
-        py::object non_const_source = const_cast<py::object&>(source);
-        PythonObjectCache::get_handle().cache_object(uuid_str, non_const_source);
-
-        // Return the UUID string
-        return json(std::string("cache_object:") + uuid_str);
-        // NOLINTEND(modernize-return-braced-init-list)
+        return std::move(list_);
     }
 
-    json cast_from_pyobject(const py::object& source)
+    if (source.is_boolean())
     {
-        return cast_from_pyobject_impl(source);
+        return py::bool_(source.get<bool>());
+    }
+    if (source.is_number_float())
+    {
+        return py::float_(source.get<double>());
+    }
+    if (source.is_number_integer())
+    {
+        return py::int_(source.get<json::number_integer_t>());
+    }
+    if (source.is_number_unsigned())
+    {
+        return py::int_(source.get<json::number_unsigned_t>());  // std::size_t ?
+    }
+    if (source.is_object())
+    {
+        py::dict dict;
+        for (const auto& it : source.items())
+        {
+            dict[py::str(it.key())] = cast_from_json(it.value());
+        }
+
+        return std::move(dict);
+    }
+    if (source.is_string())
+    {
+        return py::str(source.get<std::string>());
     }
 
-    void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level)
+    return py::none();
+    // throw std::runtime_error("Unsupported conversion type.");
+}
+
+json cast_from_pyobject_impl(const py::object& source, const std::string& parent_path = "")
+{
+    // Dont return via initializer list with JSON. It performs type deduction and gives different results
+    // NOLINTBEGIN(modernize-return-braced-init-list)
+    if (source.is_none())
     {
-        PyErr_WarnEx(PyExc_DeprecationWarning, deprecation_message.c_str(), stack_level);
+        return json();
     }
+
+    if (py::isinstance<py::dict>(source))
+    {
+        const auto py_dict = source.cast<py::dict>();
+        auto json_obj      = json::object();
+        for (const auto& p : py_dict)
+        {
+            std::string key{p.first.cast<std::string>()};
+            std::string path{parent_path + "/" + key};
+            json_obj[key] = cast_from_pyobject_impl(p.second.cast<py::object>(), path);
+        }
+
+        return json_obj;
+    }
+
+    if (py::isinstance<py::list>(source) || py::isinstance<py::tuple>(source))
+    {
+        const auto py_list = source.cast<py::list>();
+        auto json_arr      = json::array();
+        for (const auto& p : py_list)
+        {
+            json_arr.push_back(cast_from_pyobject_impl(p.cast<py::object>(), parent_path));
+        }
+
+        return json_arr;
+    }
+
+    if (py::isinstance<py::bool_>(source))
+    {
+        return json(py::cast<bool>(source));
+    }
+
+    if (py::isinstance<py::int_>(source))
+    {
+        return json(py::cast<long>(source));
+    }
+
+    if (py::isinstance<py::float_>(source))
+    {
+        return json(py::cast<double>(source));
+    }
+
+    if (py::isinstance<py::str>(source))
+    {
+        return json(py::cast<std::string>(source));
+    }
+
+    // else unsupported return throw a type error
+    // {
+    //     AcquireGIL gil;
+    //     std::ostringstream error_message;
+    //     std::string path{parent_path};
+    //     if (path.empty())
+    //     {
+    //         path = "/";
+    //     }
+
+    //     error_message << "Object (" << py::str(source).cast<std::string>() << ") of type: " <<
+    //     get_py_type_name(source)
+    //                   << " at path: " << path << " is not JSON serializable";
+
+    //     DVLOG(5) << error_message.str();
+    //     throw py::type_error(error_message.str());
+    // }
+
+    /* We don't know how to serialize the Object, throw it into cache and return a reference ID*/
+    // Use Python's uuid module to generate a UUID
+    py::object uuid_module = py::module_::import("uuid");
+    py::object uuid_obj    = uuid_module.attr("uuid4")();
+    std::string uuid_str   = py::str(uuid_obj);
+
+    // Remove constness and cache the object
+    py::object non_const_source = const_cast<py::object&>(source);
+    PythonObjectCache::get_handle().cache_object(uuid_str, non_const_source);
+
+    // Return the UUID string
+    return json(std::string("cache_object:") + uuid_str);
+    // NOLINTEND(modernize-return-braced-init-list)
+}
+
+json cast_from_pyobject(const py::object& source)
+{
+    return cast_from_pyobject_impl(source);
+}
+
+void show_deprecation_warning(const std::string& deprecation_message, ssize_t stack_level)
+{
+    PyErr_WarnEx(PyExc_DeprecationWarning, deprecation_message.c_str(), stack_level);
+}
 }  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -28,6 +28,7 @@
 #include <pyerrors.h>
 #include <warnings.h>
 
+#include <functional>  // for function
 #include <sstream>
 #include <string>
 #include <utility>

--- a/python/mrc/_pymrc/src/utils.cpp
+++ b/python/mrc/_pymrc/src/utils.cpp
@@ -169,6 +169,7 @@ json cast_from_pyobject_impl(const py::object& source,
         auto json_arr      = json::array();
         for (const auto& p : py_list)
         {
+            std::string path{parent_path + "/" + std::to_string(json_arr.size())};
             json_arr.push_back(cast_from_pyobject_impl(p.cast<py::object>(), unserializable_handler_fn, parent_path));
         }
 

--- a/python/mrc/_pymrc/tests/CMakeLists.txt
+++ b/python/mrc/_pymrc/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/tests/CMakeLists.txt
+++ b/python/mrc/_pymrc/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(test_pymrc
   test_asyncio_runnable.cpp
   test_codable_pyobject.cpp
   test_executor.cpp
+  test_json_values.cpp
   test_main.cpp
   test_object_cache.cpp
   test_pickle_wrapper.cpp

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -21,9 +21,7 @@
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
-#include <nlohmann/json_fwd.hpp>
 #include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
 
 #include <array>

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -20,8 +20,7 @@
 #include "pymrc/utilities/json_values.hpp"
 
 #include <gtest/gtest.h>
-#include <nlohmann/json_fwd.hpp>
-#include <pybind11/detail/common.h>
+#include <nlohmann/json.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
 

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -493,8 +493,15 @@ TEST_F(TestJSONValues, GetPythonError)
 TEST_F(TestJSONValues, SubscriptOpt)
 {
     using namespace nlohmann;
-    const auto json_doc            = mk_json();
-    std::vector<std::string> paths = {"/", "/this", "/this/is", "/alphabet", "/ncc", "/cost"};
+    const auto json_doc             = mk_json();
+    std::vector<std::string> values = {"", "this", "this/is", "alphabet", "ncc", "cost"};
+    std::vector<std::string> paths;
+    for (const auto& value : values)
+    {
+        paths.push_back(value);
+        paths.push_back("/" + value);
+    }
+
     for (const auto& value : {JSONValues{mk_json()}, JSONValues{mk_py_dict()}})
     {
         for (const auto& path : paths)
@@ -502,9 +509,15 @@ TEST_F(TestJSONValues, SubscriptOpt)
             auto jv = value[path];
 
             json::json_pointer jp;
-            if (path != "/")
+            if (!path.empty() && path != "/")
             {
-                jp = json::json_pointer(path);
+                std::string json_path = path;
+                if (json_path[0] != '/')
+                {
+                    json_path = "/"s + json_path;
+                }
+
+                jp = json::json_pointer(json_path);
             }
 
             EXPECT_EQ(jv.to_json(JSONValues::stringify), json_doc[jp]);

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -70,7 +70,7 @@ TEST_F(TestJSONValues, DefaultConstructor)
 {
     JSONValues j;
 
-    EXPECT_EQ(j.to_json(), nlohmann::json());
+    EXPECT_EQ(j.to_json(JSONValues::stringify), nlohmann::json());
     EXPECT_TRUE(j.to_python().is_none());
 }
 
@@ -103,24 +103,28 @@ TEST_F(TestJSONValues, ToJSONFromPython)
     py::dict py_input = mk_py_dict();
 
     JSONValues j{py_input};
-    auto result = j.to_json();
+    auto result = j.to_json(JSONValues::stringify);
 
     EXPECT_EQ(result, expected_results);
 }
 
 TEST_F(TestJSONValues, ToJSONFromPythonUnserializable)
 {
+    std::string dec_val{"2.2"};
+    auto expected_results     = mk_json();
+    expected_results["other"] = dec_val;
+
     py::dict py_input = mk_py_dict();
-    py_input["other"] = mk_decimal();
+    py_input["other"] = mk_decimal(dec_val);
 
     JSONValues j{py_input};
-    EXPECT_THROW(j.to_json(), std::runtime_error);
+    EXPECT_EQ(j.to_json(JSONValues::stringify), expected_results);
 }
 
 TEST_F(TestJSONValues, ToJSONFromJSON)
 {
     JSONValues j{mk_json()};
-    auto result = j.to_json();
+    auto result = j.to_json(JSONValues::stringify);
 
     EXPECT_EQ(result, mk_json());
 }
@@ -304,7 +308,7 @@ TEST_F(TestJSONValues, SetValueNewKeyJSON)
 
     JSONValues values{mk_json()};
     auto new_values = values.set_value("/other", mk_json());
-    EXPECT_EQ(new_values.to_json(), expected_results);
+    EXPECT_EQ(new_values.to_json(JSONValues::stringify), expected_results);
 }
 
 TEST_F(TestJSONValues, SetValueExistingKeyJSON)
@@ -315,7 +319,7 @@ TEST_F(TestJSONValues, SetValueExistingKeyJSON)
 
     JSONValues values{mk_json()};
     auto new_values = values.set_value("/this", mk_json());
-    EXPECT_EQ(new_values.to_json(), expected_results);
+    EXPECT_EQ(new_values.to_json(JSONValues::stringify), expected_results);
 }
 
 TEST_F(TestJSONValues, SetValueNewKeyJSONWithUnserializable)
@@ -388,7 +392,7 @@ TEST_F(TestJSONValues, SetValueNewKeyJSONDefaultConstructed)
 
     JSONValues values;
     auto new_values = values.set_value("/other", mk_json());
-    EXPECT_EQ(new_values.to_json(), expected_results);
+    EXPECT_EQ(new_values.to_json(JSONValues::stringify), expected_results);
 }
 
 TEST_F(TestJSONValues, SetValueJSONValues)
@@ -400,7 +404,7 @@ TEST_F(TestJSONValues, SetValueJSONValues)
     JSONValues values1{mk_json()};
     JSONValues values2{mk_json()};
     auto new_values = values1.set_value("/other", values2);
-    EXPECT_EQ(new_values.to_json(), expected_results);
+    EXPECT_EQ(new_values.to_json(JSONValues::stringify), expected_results);
 }
 
 TEST_F(TestJSONValues, SetValueJSONValuesWithUnserializable)
@@ -434,7 +438,7 @@ TEST_F(TestJSONValues, GetJSON)
             }
 
             EXPECT_TRUE(json_doc.contains(jp)) << "Path: '" << path << "' not found in json";
-            EXPECT_EQ(value.get_json(path), json_doc[jp]);
+            EXPECT_EQ(value.get_json(path, JSONValues::stringify), json_doc[jp]);
         }
     }
 }
@@ -446,7 +450,7 @@ TEST_F(TestJSONValues, GetJSONError)
     {
         for (const auto& path : paths)
         {
-            EXPECT_THROW(value.get_json(path), std::runtime_error);
+            EXPECT_THROW(value.get_json(path, JSONValues::stringify), std::runtime_error);
         }
     }
 }
@@ -503,7 +507,7 @@ TEST_F(TestJSONValues, SubscriptOpt)
                 jp = json::json_pointer(path);
             }
 
-            EXPECT_EQ(jv.to_json(), json_doc[jp]);
+            EXPECT_EQ(jv.to_json(JSONValues::stringify), json_doc[jp]);
         }
     }
 }

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -20,13 +20,17 @@
 #include "pymrc/utilities/json_values.hpp"
 
 #include <gtest/gtest.h>
-#include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
 
+#include <cstddef>  // for size_t
 #include <string>
+#include <utility>  // for pair
 #include <vector>
+// We already included pybind11.h don't need these others
+// IWYU pragma: no_include <pybind11/cast.h>
+// IWYU pragma: no_include <pybind11/eval.h>
+// IWYU pragma: no_include <pybind11/pytypes.h>
 
 namespace py = pybind11;
 using namespace mrc::pymrc;
@@ -121,4 +125,60 @@ TEST_F(TestJSONValues, ToPythonList)
     EXPECT_TRUE(result.equal(py_list));
     py::object result_dec = result[2];
     EXPECT_TRUE(result_dec.is(py_dec));
+}
+
+TEST_F(TestJSONValues, ToPythonMultipleTypes)
+{
+    // Test with miultiple types not json serializable: module, class, function, generator
+    py::object py_mod  = py::module_::import("decimal");
+    py::object py_cls  = py_mod.attr("Decimal");
+    py::object globals = py::globals();
+    py::exec(
+        R"(
+            def gen_fn():
+                yield 1
+        )",
+        globals);
+
+    py::object py_fn  = globals["gen_fn"];
+    py::object py_gen = py_fn();
+
+    std::vector<std::pair<std::size_t, py::object>> expected_list_objs = {{1, py_mod},
+                                                                          {3, py_cls},
+                                                                          {5, py_fn},
+                                                                          {7, py_gen}};
+
+    std::vector<py::object> py_values =
+        {py::cast(0), py_mod, py::cast(2), py_cls, py::cast(4), py_fn, py::cast(6), py_gen};
+    py::list py_list = py::cast(py_values);
+
+    std::vector<std::pair<std::string, py::object>> expected_dict_objs = {{"module", py_mod},
+                                                                          {"class", py_cls},
+                                                                          {"function", py_fn},
+                                                                          {"generator", py_gen}};
+
+    // Test with object in a nested dict
+    py::dict py_dict("module"_a      = py_mod,
+                     "class"_a       = py_cls,
+                     "function"_a    = py_fn,
+                     "generator"_a   = py_gen,
+                     "nested_list"_a = py_list);
+
+    JSONValues j{py_dict};
+    auto result = j.to_python();
+    EXPECT_TRUE(result.equal(py_dict));
+    EXPECT_FALSE(result.is(py_dict));  // Ensure we actually serialized the object and not stored it
+
+    for (const auto& [key, value] : expected_dict_objs)
+    {
+        py::object result_value = result[key.c_str()];
+        EXPECT_TRUE(result_value.is(value));
+    }
+
+    py::list nested_list = result["nested_list"];
+    for (const auto& [index, value] : expected_list_objs)
+    {
+        py::object result_value = nested_list[index];
+        EXPECT_TRUE(result_value.is(value));
+    }
 }

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -17,6 +17,7 @@
 
 #include "test_pymrc.hpp"
 
+#include "pymrc/types.hpp"
 #include "pymrc/utilities/json_values.hpp"
 
 #include <gtest/gtest.h>
@@ -481,6 +482,40 @@ TEST_F(TestJSONValues, GetPythonError)
         for (const auto& path : paths)
         {
             EXPECT_THROW(value.get_python(path), std::runtime_error) << "Expected failure with path: '" << path << "'";
+        }
+    }
+}
+
+TEST_F(TestJSONValues, SubscriptOpt)
+{
+    using namespace nlohmann;
+    const auto json_doc            = mk_json();
+    std::vector<std::string> paths = {"/", "/this", "/this/is", "/alphabet", "/ncc", "/cost"};
+    for (const auto& value : {JSONValues{mk_json()}, JSONValues{mk_py_dict()}})
+    {
+        for (const auto& path : paths)
+        {
+            auto jv = value[path];
+
+            json::json_pointer jp;
+            if (path != "/")
+            {
+                jp = json::json_pointer(path);
+            }
+
+            EXPECT_EQ(jv.to_json(), json_doc[jp]);
+        }
+    }
+}
+
+TEST_F(TestJSONValues, SubscriptOptError)
+{
+    std::vector<std::string> paths = {"/doesntexist", "/this/fake"};
+    for (const auto& value : {JSONValues{mk_json()}, JSONValues{mk_py_dict()}})
+    {
+        for (const auto& path : paths)
+        {
+            EXPECT_THROW(value[path], std::runtime_error);
         }
     }
 }

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -64,6 +64,14 @@ py::object mk_decimal(const std::string& value = "1.0"s)
     return py::module_::import("decimal").attr("Decimal")(value);
 }
 
+TEST_F(TestJSONValues, DefaultConstructor)
+{
+    JSONValues j;
+
+    EXPECT_EQ(j.to_json(), nlohmann::json());
+    EXPECT_TRUE(j.to_python().is_none());
+}
+
 TEST_F(TestJSONValues, ToPythonSerializable)
 {
     auto py_dict = mk_py_dict();

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -523,3 +523,9 @@ TEST_F(TestJSONValues, SubscriptOptError)
         }
     }
 }
+
+TEST_F(TestJSONValues, Stringify)
+{
+    auto dec_val = mk_decimal("2.2"s);
+    EXPECT_EQ(JSONValues::stringify(dec_val, "/"s), nlohmann::json("2.2"s));
+}

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -18,23 +18,14 @@
 #include "test_pymrc.hpp"
 
 #include "pymrc/utilities/json_values.hpp"
-#include "pymrc/utils.hpp"  // for imort_module_object
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>  // IWYU pragma: keep
 
-#include <array>
-#include <cfloat>
-#include <climits>
-#include <map>
-#include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace py = pybind11;

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -62,7 +62,6 @@ TEST_F(TestJSONValues, ToPythonRootUnserializable)
 
     JSONValues j{py_dec};
     auto result = j.to_python();
-    py::print(result);
 
     EXPECT_TRUE(result.equal(py_dec));
     EXPECT_TRUE(result.is(py_dec));  // Ensure we stored the object
@@ -76,7 +75,6 @@ TEST_F(TestJSONValues, ToPythonSimpleDict)
 
     JSONValues j{py_dict};
     py::dict result = j.to_python();
-    py::print(result);  // TODO: Remove
 
     EXPECT_TRUE(result.equal(py_dict));
     EXPECT_FALSE(result.is(py_dict));  // Ensure we actually serialized the dict and not stored it

--- a/python/mrc/_pymrc/tests/test_json_values.cpp
+++ b/python/mrc/_pymrc/tests/test_json_values.cpp
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_pymrc.hpp"
+
+#include "pymrc/utilities/json_values.hpp"
+#include "pymrc/utils.hpp"  // for imort_module_object
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>  // IWYU pragma: keep
+
+#include <array>
+#include <cfloat>
+#include <climits>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace py = pybind11;
+using namespace mrc::pymrc;
+using namespace std::string_literals;
+using namespace pybind11::literals;  // to bring in the `_a` literal
+
+PYMRC_TEST_CLASS(JSONValues);
+
+TEST_F(TestJSONValues, ToPythonSerializable)
+{
+    py::dict py_dict;
+    py_dict[py::str("test"s)] = py::str("this"s);
+
+    JSONValues j{py_dict};
+    auto result = j.to_python();
+
+    EXPECT_EQ(result, py_dict);
+    EXPECT_FALSE(result.is(py_dict));  // Ensure we actually serialized the object and not stored it
+}
+
+TEST_F(TestJSONValues, ToPythonRootUnserializable)
+{
+    py::object py_dec = py::module_::import("decimal").attr("Decimal")("1.0");
+
+    JSONValues j{py_dec};
+    auto result = j.to_python();
+
+    EXPECT_TRUE(result.is(py_dec));  // Ensure we stored the object
+}
+
+TEST_F(TestJSONValues, ToPythonNestedDictUnserializable)
+{
+    // decimal.Decimal is not serializable
+    py::object Decimal = py::module_::import("decimal").attr("Decimal");
+
+    py::object py_dec1 = Decimal("1.1");
+    py::object py_dec2 = Decimal("1.2");
+    py::object py_dec3 = Decimal("1.3");
+
+    std::vector<py::object> py_values = {py::cast(1), py::cast(2), py_dec3, py::cast(4)};
+    py::list py_list                  = py::cast(py_values);
+
+    // Test with object in a nested dict
+    py::dict py_dict("a"_a           = py::dict("b"_a = py::dict("c"_a = py::dict("d"_a = py_dec1))),
+                     "other"_a       = py_dec2,
+                     "nested_list"_a = py_list);
+
+    JSONValues j{py_dict};
+    auto result = j.to_python();
+    EXPECT_EQ(result, py_dict);
+    EXPECT_FALSE(result.is(py_dict));  // Ensure we actually serialized the object and not stored it
+
+    // Individual Decimal instances shoudl be stored and thus pass an `is` test
+    py::object result_dec1 = result["a"]["b"]["c"]["d"];
+    EXPECT_TRUE(result_dec1.is(py_dec1));
+
+    py::object result_dec2 = result["other"];
+    EXPECT_TRUE(result_dec2.is(py_dec2));
+
+    py::list nested_list   = result["nested_list"];
+    py::object result_dec3 = nested_list[2];
+    EXPECT_TRUE(result_dec3.is(py_dec3));
+}
+
+TEST_F(TestJSONValues, ToPythonList) {}

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -34,7 +34,6 @@
 #include <climits>
 #include <map>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -158,6 +157,17 @@ TEST_F(TestUtils, CastFromPyObjectSerializeErrors)
     // Test with object in a nested dict
     py::dict d("a"_a = py::dict("b"_a = py::dict("c"_a = py::dict("d"_a = o))), "other"_a = 2);
     EXPECT_THROW(pymrc::cast_from_pyobject(d), py::type_error);
+}
+
+TEST_F(TestUtils, GetTypeName)
+{
+    // invalid objects should return an empty string
+    EXPECT_EQ(pymrc::get_py_type_name(py::object()), "");
+    EXPECT_EQ(pymrc::get_py_type_name(py::none()), "NoneType");
+
+    py::object Decimal = py::module_::import("decimal").attr("Decimal");
+    py::object o       = Decimal("1.0");
+    EXPECT_EQ(pymrc::get_py_type_name(o), "Decimal");
 }
 
 TEST_F(TestUtils, PyObjectWrapper)

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -24,6 +24,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -157,6 +158,47 @@ TEST_F(TestUtils, CastFromPyObjectSerializeErrors)
     // Test with object in a nested dict
     py::dict d("a"_a = py::dict("b"_a = py::dict("c"_a = py::dict("d"_a = o))), "other"_a = 2);
     EXPECT_THROW(pymrc::cast_from_pyobject(d), py::type_error);
+}
+
+TEST_F(TestUtils, CastFromPyObjectUnserializableHandlerFn)
+{
+    // Test to verify that cast_from_pyobject calls the unserializable_handler_fn when encountering an object that it
+    // does not know how to serialize
+
+    bool handler_called{false};
+    pymrc::unserializable_handler_fn_t handler_fn = [&handler_called](const py::object& source,
+                                                                      const std::string& path) {
+        handler_called = true;
+        return nlohmann::json(py::cast<float>(source));
+    };
+
+    // decimal.Decimal is not serializable
+    py::object Decimal = py::module_::import("decimal").attr("Decimal");
+    py::object o       = Decimal("1.0");
+    EXPECT_EQ(pymrc::cast_from_pyobject(o, handler_fn), nlohmann::json(1.0));
+    EXPECT_TRUE(handler_called);
+}
+
+TEST_F(TestUtils, CastFromPyObjectUnserializableHandlerFnNestedObj)
+{
+    std::size_t handler_call_count{0};
+
+    // Test with object in a nested dict
+    pymrc::unserializable_handler_fn_t handler_fn = [&handler_call_count](const py::object& source,
+                                                                          const std::string& path) {
+        ++handler_call_count;
+        return nlohmann::json(py::cast<float>(source));
+    };
+
+    // decimal.Decimal is not serializable
+    py::object Decimal = py::module_::import("decimal").attr("Decimal");
+    py::object o       = Decimal("1.0");
+
+    py::dict d("a"_a = py::dict("b"_a = py::dict("c"_a = py::dict("d"_a = o))), "other"_a = o);
+    nlohmann::json expected_results = {{"a", {{"b", {{"c", {{"d", 1.0}}}}}}}, {"other", 1.0}};
+
+    EXPECT_EQ(pymrc::cast_from_pyobject(d, handler_fn), expected_results);
+    EXPECT_EQ(handler_call_count, 2);
 }
 
 TEST_F(TestUtils, GetTypeName)

--- a/python/mrc/_pymrc/tests/test_utils.cpp
+++ b/python/mrc/_pymrc/tests/test_utils.cpp
@@ -24,7 +24,6 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
-#include <nlohmann/json_fwd.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -33,6 +32,7 @@
 #include <array>
 #include <cfloat>
 #include <climits>
+#include <cstddef>  // for size_t
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description
* Add an optional `unserializable_handler_fn` callback to `mrc::pymrc::cast_from_pyobject` which will be invoked for any unsupported Python object. Allowing for serializing unsupported object.
ex:
```cpp
    pymrc::unserializable_handler_fn_t handler_fn = [](const py::object& source,
                                                       const std::string& path) {
        return nlohmann::json(py::cast<float>(source));
    };

    // decimal.Decimal is not serializable
    py::object Decimal = py::module_::import("decimal").attr("Decimal");
    py::object o       = Decimal("1.0");
    EXPECT_EQ(pymrc::cast_from_pyobject(o, handler_fn), nlohmann::json(1.0));
```

* Add `JSONValues` container class which is an immutable container for holding Python values as `nlohmann::json` objects if possible, and as `pybind11::object` otherwise. The container can be copied and moved, but the underlying `nlohmann::json` object is immutable.
* Updates `nlohmann_json` from 3.9 to 3.11 for `patch_inplace` method.
* Incorporates ideas from @drobison00's PR #417 with three key differences:

  1. Changes to the `cast_from_pyobject` are opt-in when `unserializable_handler_fn` is provided, otherwise there is no behavior change to the method.
  2. Unserializable objects are stored in `JSONValues` rather than a global cache.
  3. Does not rely on parsing the place-holder values.

This PR is related to nv-morpheus/Morpheus#1560

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
