### PR TITLE
Fix load_module bug with unserializable objects

### DIFF
--- a/python/mrc/_pymrc/include/pymrc/types.hpp
+++ b/python/mrc/_pymrc/include/pymrc/types.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +21,12 @@
 
 #include "mrc/segment/object.hpp"
 
+#include <nlohmann/json_fwd.hpp>
 #include <rxcpp/rx.hpp>
 
-#include <functional>
+#include <functional>  // for function
+#include <map>
+#include <string>
 
 namespace mrc::pymrc {
 
@@ -36,5 +39,17 @@ using PyObjectObservable = rxcpp::observable<PyHolder>;
 using PyNode             = mrc::segment::ObjectProperties;
 using PyObjectOperateFn  = std::function<PyObjectObservable(PyObjectObservable source)>;
 // NOLINTEND(readability-identifier-naming)
+
+using python_map_t = std::map<std::string, pybind11::object>;
+
+/**
+ * @brief Unserializable handler function type, invoked by `cast_from_pyobject` when an object cannot be serialized to
+ * JSON. Implementations should return a valid json object, or throw an exception if the object cannot be serialized.
+ * @param source : pybind11 object
+ * @param path : string json path to object
+ * @return nlohmann::json.
+ */
+using unserializable_handler_fn_t =
+    std::function<nlohmann::json(const pybind11::object& /* source*/, const std::string& /* path */)>;
 
 }  // namespace mrc::pymrc

--- a/python/mrc/_pymrc/include/pymrc/utils.hpp
+++ b/python/mrc/_pymrc/include/pymrc/utils.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "pymrc/types.hpp"
+
 #include <nlohmann/json_fwd.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -31,7 +33,24 @@ namespace mrc::pymrc {
 #pragma GCC visibility push(default)
 
 pybind11::object cast_from_json(const nlohmann::json& source);
+
+/**
+ * @brief Convert a pybind11 object to a JSON object. If the object cannot be serialized, a pybind11::type_error
+ * exception be thrown.
+ * @param source : pybind11 object
+ * @return nlohmann::json.
+ */
 nlohmann::json cast_from_pyobject(const pybind11::object& source);
+
+/**
+ * @brief Convert a pybind11 object to a JSON object. If the object cannot be serialized, the unserializable_handler_fn
+ * will be invoked to handle the object.
+ * @param source : pybind11 object
+ * @param unserializable_handler_fn : unserializable_handler_fn_t
+ * @return nlohmann::json.
+ */
+nlohmann::json cast_from_pyobject(const pybind11::object& source,
+                                  unserializable_handler_fn_t unserializable_handler_fn);
 
 void import_module_object(pybind11::module_&, const std::string&, const std::string&);
 void import_module_object(pybind11::module_& dest, const pybind11::module_& mod);

--- a/python/mrc/_pymrc/src/module_registry.cpp
+++ b/python/mrc/_pymrc/src/module_registry.cpp
@@ -59,7 +59,10 @@ pybind11::cpp_function ModuleRegistryProxy::get_module_constructor(const std::st
 {
     auto fn_constructor    = modules::ModuleRegistry::get_module_constructor(name, registry_namespace);
     auto py_module_wrapper = [fn_constructor](std::string module_name, pybind11::dict config) {
-        auto json_config = cast_from_pyobject(config);
+        auto json_config = cast_from_pyobject(config, [](const pybind11::object&, const std::string& path) {
+            DVLOG(10) << "Could not serialize object at path: " << path;
+            return nlohmann::json();  // Return a null json object if we can't convert
+        });
         return fn_constructor(std::move(module_name), std::move(json_config));
     };
 

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -459,7 +459,10 @@ std::shared_ptr<mrc::modules::SegmentModule> BuilderProxy::load_module_from_regi
     std::string module_name,
     py::dict config)
 {
-    auto json_config = cast_from_pyobject(config);
+    auto json_config = cast_from_pyobject(config, [](const py::object&, const std::string& path) {
+        DVLOG(10) << "Could not serialize object at path: " << path;
+        return nlohmann::json();  // Return a null json object if we can't convert
+    });
 
     return self.load_module_from_registry(module_id, registry_namespace, std::move(module_name), std::move(json_config));
 }

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -33,6 +33,7 @@
 #include "mrc/segment/object.hpp"
 
 #include <glog/logging.h>
+#include <nlohmann/json.hpp>
 #include <pybind11/cast.h>
 #include <pybind11/gil.h>
 #include <pybind11/pytypes.h>

--- a/python/tests/test_module_registry.py
+++ b/python/tests/test_module_registry.py
@@ -135,12 +135,12 @@ def test_get_module_constructor():
         registry.get_module_constructor("SimpleModule", "default")
 
 
-@pytest.mark.parametrize("config,name", [({"a": "b"}, "serializable"), ({"now": datetime.now()}, "unserializable")])
-def test_module_config(config: dict, name: str):
+def test_module_config():
     """
     Repro test for #461
     """
-    module_name = f"test_py_mod_config_{name}"
+    config = {"now": datetime.now()}
+    module_name = f"test_py_mod_config_unserializable"
     registry = mrc.ModuleRegistry
 
     def module_initializer(builder: mrc.Builder):

--- a/python/tests/test_module_registry.py
+++ b/python/tests/test_module_registry.py
@@ -140,7 +140,7 @@ def test_module_config():
     Repro test for #461
     """
     config = {"now": datetime.now()}
-    module_name = f"test_py_mod_config_unserializable"
+    module_name = "test_py_mod_config_unserializable"
     registry = mrc.ModuleRegistry
 
     def module_initializer(builder: mrc.Builder):

--- a/python/tests/test_module_registry.py
+++ b/python/tests/test_module_registry.py
@@ -135,32 +135,25 @@ def test_get_module_constructor():
         registry.get_module_constructor("SimpleModule", "default")
 
 
-@pytest.mark.parametrize("config", [{"a": "b"}, {"now": datetime.now()}], ids=["serializable", "unserializable"])
-def test_module_config(config: dict):
+@pytest.mark.parametrize("config,name", [({"a": "b"}, "serializable"), ({"now": datetime.now()}, "unserializable")])
+def test_module_config(config: dict, name: str):
     """
     Repro test for #461
     """
-    module_name = "test_py_mod_config"
+    module_name = f"test_py_mod_config_{name}"
     registry = mrc.ModuleRegistry
 
     def module_initializer(builder: mrc.Builder):
-        print("mi 0", flush=True)
         source_mod = builder.load_module("SourceModule", "mrc_unittest", "ModuleSourceTest_mod1", config)
-        print("mi 1", flush=True)
         builder.register_module_output("source", source_mod.output_port("source"))
-        print("mi 2", flush=True)
 
     def init_wrapper(builder: mrc.Builder):
-        print(0, flush=True)
         # Retrieve the module constructor
         fn_constructor = registry.get_module_constructor(module_name, "mrc_unittest")
-        print(1, flush=True)
+
         # Instantiate a version of the module
         source_module = fn_constructor("ModuleSourceTest_mod1", config)
-        print(2, flush=True)
-
         builder.init_module(source_module)
-        print(3, flush=True)
 
     # Register the module
     registry.register_module(module_name, "mrc_unittest", VERSION, module_initializer)


### PR DESCRIPTION
## Description
* PR #451 changed the `cast_from_pyobject` behavior to throw an exception rather than returning a null.
* This broke `dfp_integrated_training_batch_pipeline.py` which stored `datetime` objects in the module config. 
* This PR back-patches the `unserializable_handler_fn` functionality from 24.06, and adds a handler to `ModuleRegistryProxy::get_module_constructor` and `BuilderProxy::load_module_from_registry` to restore the original functionality as a quick-fix for 24.03

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
