### PR TITLE
Downgrade doxygen to match Morpheus

### DIFF
--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - cuda-tools=12.1
 - cuda-version=12.1
 - cxx-compiler
-- doxygen=1.10.0
+- doxygen=1.9.2
 - flake8
 - gcovr=5.2
 - gdb

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cuda-tools=12.1
 - cuda-version=12.1
 - cxx-compiler
-- doxygen=1.10.0
+- doxygen=1.9.2
 - gcovr=5.2
 - glog=0.6
 - gtest=1.14

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -130,7 +130,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - doxygen=1.10.0
+          - doxygen=1.9.2
           - python-graphviz
 
   python:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Morpheus documentation won't build with doxygen 1.10.0, but we need MRC and Morpheus doxygen versions to match so cross-repository environments can be solved correctly. This PR downgrades doxygen to the version used by Morpheus.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
