### PR TITLE
Add auto register helpers to AsyncSink and AsyncSource

### DIFF
--- a/ci/scripts/cpp_checks.sh
+++ b/ci/scripts/cpp_checks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/scripts/cpp_checks.sh
+++ b/ci/scripts/cpp_checks.sh
@@ -84,19 +84,21 @@ if [[ -n "${MRC_MODIFIED_FILES}" ]]; then
       shopt -s extglob
       IWYU_MODIFIED_FILES=( "${MRC_MODIFIED_FILES[@]/*.@(h|hpp|cu)/}" )
 
-      # Get the list of compiled files relative to this directory
-      WORKING_PREFIX="${PWD}/"
-      COMPILED_FILES=( $(jq -r .[].file ${BUILD_DIR}/compile_commands.json | sort -u ) )
-      COMPILED_FILES=( "${COMPILED_FILES[@]/#$WORKING_PREFIX/}" )
-      COMBINED_FILES=("${COMPILED_FILES[@]}")
-      COMBINED_FILES+=("${IWYU_MODIFIED_FILES[@]}")
+      if [[ -n "${IWYU_MODIFIED_FILES}" ]]; then
+         # Get the list of compiled files relative to this directory
+         WORKING_PREFIX="${PWD}/"
+         COMPILED_FILES=( $(jq -r .[].file ${BUILD_DIR}/compile_commands.json | sort -u ) )
+         COMPILED_FILES=( "${COMPILED_FILES[@]/#$WORKING_PREFIX/}" )
+         COMBINED_FILES=("${COMPILED_FILES[@]}")
+         COMBINED_FILES+=("${IWYU_MODIFIED_FILES[@]}")
 
-      # Find the intersection between compiled files and modified files
-      IWYU_MODIFIED_FILES=( $(printf '%s\0' "${COMBINED_FILES[@]}" | sort -z | uniq -d -z | xargs -0n1) )
+         # Find the intersection between compiled files and modified files
+         IWYU_MODIFIED_FILES=( $(printf '%s\0' "${COMBINED_FILES[@]}" | sort -z | uniq -d -z | xargs -0n1) )
 
-      NUM_PROC=$(get_num_proc)
-      IWYU_OUTPUT=`${IWYU_TOOL} -p ${BUILD_DIR} -j ${NUM_PROC} ${IWYU_MODIFIED_FILES[@]} 2>&1`
-      IWYU_RETVAL=$?
+         NUM_PROC=$(get_num_proc)
+         IWYU_OUTPUT=`${IWYU_TOOL} -p ${BUILD_DIR} -j ${NUM_PROC} ${IWYU_MODIFIED_FILES[@]} 2>&1`
+         IWYU_RETVAL=$?
+      fi
    fi
 else
    echo "No modified C++ files to check"

--- a/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
+++ b/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
@@ -18,6 +18,8 @@
 #pragma once
 
 #include "pymrc/asyncio_scheduler.hpp"
+#include "pymrc/edge_adapter.hpp"
+#include "pymrc/node.hpp"
 #include "pymrc/utilities/object_wrappers.hpp"
 
 #include <boost/fiber/future/async.hpp>
@@ -110,7 +112,8 @@ class BoostFutureAwaitableOperation
 template <typename T>
 class AsyncSink : public mrc::node::WritableProvider<T>,
                   public mrc::node::ReadableAcceptor<T>,
-                  public mrc::node::SinkChannelOwner<T>
+                  public mrc::node::SinkChannelOwner<T>,
+                  public pymrc::AutoRegSinkAdapter<T>
 {
   protected:
     AsyncSink() :
@@ -140,7 +143,8 @@ class AsyncSink : public mrc::node::WritableProvider<T>,
 template <typename T>
 class AsyncSource : public mrc::node::WritableAcceptor<T>,
                     public mrc::node::ReadableProvider<T>,
-                    public mrc::node::SourceChannelOwner<T>
+                    public mrc::node::SourceChannelOwner<T>,
+                    public pymrc::AutoRegSourceAdapter<T>
 {
   protected:
     AsyncSource() :

--- a/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
+++ b/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
@@ -113,7 +113,8 @@ template <typename T>
 class AsyncSink : public mrc::node::WritableProvider<T>,
                   public mrc::node::ReadableAcceptor<T>,
                   public mrc::node::SinkChannelOwner<T>,
-                  public pymrc::AutoRegSinkAdapter<T>
+                  public pymrc::AutoRegSinkAdapter<T>,
+                  public pymrc::AutoRegEgressPort<T>
 {
   protected:
     AsyncSink() :
@@ -144,7 +145,8 @@ template <typename T>
 class AsyncSource : public mrc::node::WritableAcceptor<T>,
                     public mrc::node::ReadableProvider<T>,
                     public mrc::node::SourceChannelOwner<T>,
-                    public pymrc::AutoRegSourceAdapter<T>
+                    public pymrc::AutoRegSourceAdapter<T>,
+                    public pymrc::AutoRegIngressPort<T>
 {
   protected:
     AsyncSource() :


### PR DESCRIPTION
## Description
* Adds `AutoRegSinkAdapter` and `AutoRegEgressPort` to `AsyncSink`
* Adds `AutoRegSourceAdapter` and `AutoRegIngressPort` to `AsyncSource`
* Giving `AsyncSink`, `AsyncSource` and `AsyncioRunnable` the same implicit converter functionality that `PythonNode` has
* Fixes unrelated CI issue for IWYU, since IWYU can only run on compilation units, we can't execute it when a change only includes header files.

Closes nv-morpheus/Morpheus#1626

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
