### PR TITLE
Upgrade to RAPIDS 24.06

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
     needs: [prepare]
     if: ${{ !fromJSON(needs.prepare.outputs.has_skip_ci_label) && fromJSON(needs.prepare.outputs.is_pr )}}
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.02
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.06
     with:
       enable_check_generated_files: false
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
     needs: [prepare]
     if: ${{ !fromJSON(needs.prepare.outputs.has_skip_ci_label) && fromJSON(needs.prepare.outputs.is_pr )}}
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.06
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.02
     with:
       enable_check_generated_files: false
 

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -24,7 +24,7 @@ rapids-dependency-file-generator \
   --file_key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
-rapids-mamba-retry env create --force -f env.yaml -n checks
+rapids-mamba-retry env create --yes -f env.yaml -n checks
 conda activate checks
 
 # Run pre-commit checks

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -22,7 +22,7 @@ rapids-logger "Create checks conda environment"
 rapids-dependency-file-generator \
   --output conda \
   --file_key checks \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=3.10" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks
 conda activate checks

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -22,7 +22,7 @@ rapids-logger "Create checks conda environment"
 rapids-dependency-file-generator \
   --output conda \
   --file_key checks \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=3.10" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks
 conda activate checks

--- a/ci/conda/recipes/libmrc/conda_build_config.yaml
+++ b/ci/conda/recipes/libmrc/conda_build_config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,4 +30,4 @@ python:
 
 # Setup the dependencies to build with multiple versions of RAPIDS
 rapids_version: # Keep around compatibility with current version -2
-  - 24.02
+  - 24.06

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - pybind11-stubgen =0.10
     - python {{ python }}
     - scikit-build =0.17
-    - ucx =1.15
+    - ucx =1.16
 
 outputs:
   - name: libmrc
@@ -91,12 +91,12 @@ outputs:
         - libhwloc =2.9.2
         - librmm {{ rapids_version }}
         - nlohmann_json =3.11
-        - ucx =1.15
+        - ucx =1.16
       run:
         # Manually add any packages necessary for run that do not have run_exports. Keep sorted!
         - cuda-version {{ cuda_version }}.*
         - nlohmann_json =3.11
-        - ucx =1.15
+        - ucx =1.16
         - cuda-cudart
         - boost-cpp =1.84
     test:

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - cuda-nvrtc-dev {{ cuda_version }}.*
     - cuda-version {{ cuda_version }}.*
     - doxygen 1.10.0
-    - glog =0.6
+    - glog =0.7
     - libgrpc =1.59
     - gtest =1.14
     - libhwloc =2.9.2
@@ -86,7 +86,7 @@ outputs:
         # Any libraries with weak run_exports need to go here to be added to the run. Keep sorted!
         - boost-cpp =1.84
         - cuda-version # Needed to allow pin_compatible to work
-        - glog =0.6
+        - glog =0.7
         - libgrpc =1.59
         - libhwloc =2.9.2
         - librmm {{ rapids_version }}

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - pybind11-stubgen =0.10
     - python {{ python }}
     - scikit-build =0.17
-    - ucx =1.16
+    - ucx =1.15
 
 outputs:
   - name: libmrc
@@ -91,12 +91,12 @@ outputs:
         - libhwloc =2.9.2
         - librmm {{ rapids_version }}
         - nlohmann_json =3.11
-        - ucx =1.16
+        - ucx =1.15
       run:
         # Manually add any packages necessary for run that do not have run_exports. Keep sorted!
         - cuda-version {{ cuda_version }}.*
         - nlohmann_json =3.11
-        - ucx =1.16
+        - ucx =1.15
         - cuda-cudart
         - boost-cpp =1.84
     test:

--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - cuda-version {{ cuda_version }}.*
     - doxygen 1.10.0
     - glog =0.7
-    - libgrpc =1.59
+    - libgrpc =1.62
     - gtest =1.14
     - libhwloc =2.9.2
     - librmm {{ rapids_version }}
@@ -87,7 +87,7 @@ outputs:
         - boost-cpp =1.84
         - cuda-version # Needed to allow pin_compatible to work
         - glog =0.7
-        - libgrpc =1.59
+        - libgrpc =1.62
         - libhwloc =2.9.2
         - librmm {{ rapids_version }}
         - nlohmann_json =3.11

--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -95,7 +95,7 @@ fi
 # Choose default variants
 if hasArg quick; then
    # For quick build, just do most recent version of rapids
-   CONDA_ARGS_ARRAY+=("--variants" "{rapids_version: 24.02}")
+   CONDA_ARGS_ARRAY+=("--variants" "{rapids_version: 24.06}")
 fi
 
 # And default channels (should match dependencies.yaml)

--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -21,6 +21,7 @@ cd mrc/
 git checkout ${GIT_BRANCH}
 git pull
 git checkout ${GIT_COMMIT}
+git fetch --tags
 
 export MRC_ROOT=$(pwd)
 export WORKSPACE=${MRC_ROOT}

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -27,13 +27,13 @@ dependencies:
 - flake8
 - gcovr=5.2
 - gdb
-- glog=0.6
+- glog=0.7
 - gtest=1.14
 - gxx=11.2
 - include-what-you-use=0.20
 - libclang-cpp=16
 - libclang=16
-- libgrpc=1.59
+- libgrpc=1.62
 - libhwloc=2.9.2
 - librmm=24.06
 - libxml2=2.11.6

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -51,6 +51,6 @@ dependencies:
 - python-graphviz
 - python=3.10
 - scikit-build=0.17
-- ucx=1.15
+- ucx=1.16
 - yapf
 name: all_cuda-121_arch-x86_64

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -51,6 +51,6 @@ dependencies:
 - python-graphviz
 - python=3.10
 - scikit-build=0.17
-- ucx=1.16
+- ucx=1.15
 - yapf
 name: all_cuda-121_arch-x86_64

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -35,7 +35,7 @@ dependencies:
 - libclang=16
 - libgrpc=1.59
 - libhwloc=2.9.2
-- librmm=24.02
+- librmm=24.06
 - libxml2=2.11.6
 - llvmdev=16
 - ninja=1.11

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -40,5 +40,5 @@ dependencies:
 - python-graphviz
 - python=3.10
 - scikit-build=0.17
-- ucx=1.15
+- ucx=1.16
 name: ci_cuda-121_arch-x86_64

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -20,11 +20,11 @@ dependencies:
 - cxx-compiler
 - doxygen=1.9.2
 - gcovr=5.2
-- glog=0.6
+- glog=0.7
 - gtest=1.14
 - gxx=11.2
 - include-what-you-use=0.20
-- libgrpc=1.59
+- libgrpc=1.62
 - libhwloc=2.9.2
 - librmm=24.06
 - libxml2=2.11.6

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - include-what-you-use=0.20
 - libgrpc=1.59
 - libhwloc=2.9.2
-- librmm=24.02
+- librmm=24.06
 - libxml2=2.11.6
 - ninja=1.11
 - nlohmann_json=3.11

--- a/conda/environments/ci_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-121_arch-x86_64.yaml
@@ -40,5 +40,5 @@ dependencies:
 - python-graphviz
 - python=3.10
 - scikit-build=0.17
-- ucx=1.16
+- ucx=1.15
 name: ci_cuda-121_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ dependencies:
           - pkg-config=0.29
           - pybind11-stubgen=0.10
           - scikit-build=0.17
-          - ucx=1.16
+          - ucx=1.15
 
   checks:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ dependencies:
           - pkg-config=0.29
           - pybind11-stubgen=0.10
           - scikit-build=0.17
-          - ucx=1.15
+          - ucx=1.16
 
   checks:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -55,10 +55,10 @@ dependencies:
           - cmake=3.27
           - cuda-nvcc
           - cxx-compiler
-          - glog=0.6
+          - glog=0.7
           - gtest=1.14
           - gxx=11.2
-          - libgrpc=1.59
+          - libgrpc=1.62
           - libhwloc=2.9.2
           - librmm=24.06
           - libxml2=2.11.6 # 2.12 has a bug preventing round-trip serialization in hwloc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ dependencies:
           - gxx=11.2
           - libgrpc=1.59
           - libhwloc=2.9.2
-          - librmm=24.02
+          - librmm=24.06
           - libxml2=2.11.6 # 2.12 has a bug preventing round-trip serialization in hwloc
           - ninja=1.11
           - nlohmann_json=3.11

--- a/python/mrc/_pymrc/src/logging.cpp
+++ b/python/mrc/_pymrc/src/logging.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/src/logging.cpp
+++ b/python/mrc/_pymrc/src/logging.cpp
@@ -88,7 +88,8 @@ void log(const std::string& msg, int py_level, const std::string& filename, int 
         LOG(WARNING) << "Log called prior to calling init_logging, initialized with defaults";
     }
 
-    google::LogMessage(filename.c_str(), line, static_cast<int>(py_level_to_mrc(py_level))).stream() << msg;
+    google::LogMessage(filename.c_str(), line, static_cast<google::LogSeverity>(py_level_to_mrc(py_level))).stream()
+        << msg;
 }
 
 }  // namespace mrc::pymrc


### PR DESCRIPTION
## Description
* Update librmm
* Update glog & libgrpc to compatible versions

Unrelated fixes:
* Stop using `--force` in `ci/check_style.sh` as this flag was removed from conda
* Fetch tags when running CI locally

Requires nv-morpheus/utilities#71
Closes #478

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
