### PR TITLE
resolve rapids-dependency-file-generator warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.7.1
+        rev: v1.13.11
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -21,7 +21,7 @@ rapids-logger "Create checks conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key checks \
+  --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -24,7 +24,7 @@ rapids-dependency-file-generator \
   --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
-rapids-mamba-retry env create --force -f env.yaml -n checks
+rapids-mamba-retry env create --yes -f env.yaml -n checks
 conda activate checks
 
 # Run pre-commit checks


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89.

`--file_key` has been deprecated in `rapids-dependency-file-generator` for a few months, and I'm looking to fully remove it.

This PR proposes:

* switching this project's uses from `--file_key` to `--file-key`
* updating the version of `rapids-dependency-file-generator` used in `pre-commit` to its latest release
* switching from `mamba env create --force` to `mamba env create --yes`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
