### PR TITLE
Fix issue where Python sources can deadlock when the subscriber is unsubscribed

### DIFF
--- a/cpp/mrc/src/internal/service.hpp
+++ b/cpp/mrc/src/internal/service.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/mrc/src/internal/service.hpp
+++ b/cpp/mrc/src/internal/service.hpp
@@ -36,7 +36,7 @@ enum class ServiceState
 };
 
 /**
- * @brief Converts a `AsyncServiceState` enum to a string
+ * @brief Converts a `ServiceState` enum to a string
  *
  * @param f
  * @return std::string

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -233,6 +233,11 @@ std::shared_ptr<mrc::segment::ObjectProperties> build_source(mrc::segment::IBuil
                 {
                     subscriber.on_next(std::move(next_val));
                 }
+                else
+                {
+                    DVLOG(10) << ctx.info() << " Source unsubscribed. Stopping";
+                    break;
+                }
             }
 
         } catch (const std::exception& e)

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -150,14 +150,16 @@ class PyIteratorIterator
         while (subscriber.is_subscribed() && future_status != std::future_status::ready)
         {
             future_status = future.wait_for(std::chrono::milliseconds(100));
-            if (future_status == std::future_status::ready)
-            {
-                future.get();
-            }
-            else
+
+            if (future_status != std::future_status::ready)
             {
                 std::this_thread::yield();
             }
+        }
+
+        if (future_status == std::future_status::ready)
+        {
+            future.get();
         }
     }
 

--- a/python/mrc/_pymrc/src/utilities/acquire_gil.cpp
+++ b/python/mrc/_pymrc/src/utilities/acquire_gil.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/src/utilities/acquire_gil.cpp
+++ b/python/mrc/_pymrc/src/utilities/acquire_gil.cpp
@@ -17,15 +17,12 @@
 
 #include "pymrc/utilities/acquire_gil.hpp"
 
-#include <nlohmann/json_fwd.hpp>
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>
 
 namespace mrc::pymrc {
 
 namespace py = pybind11;
-
-using nlohmann::json;
 
 AcquireGIL::AcquireGIL() : m_gil(std::make_unique<py::gil_scoped_acquire>()) {}
 

--- a/python/mrc/_pymrc/tests/test_executor.cpp
+++ b/python/mrc/_pymrc/tests/test_executor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/tests/test_executor.cpp
+++ b/python/mrc/_pymrc/tests/test_executor.cpp
@@ -19,8 +19,6 @@
 
 #include "pymrc/executor.hpp"
 #include "pymrc/pipeline.hpp"
-#include "pymrc/types.hpp"
-#include "pymrc/utilities/object_wrappers.hpp"
 
 #include "mrc/node/rx_node.hpp"
 #include "mrc/node/rx_sink.hpp"

--- a/python/mrc/_pymrc/tests/test_executor.cpp
+++ b/python/mrc/_pymrc/tests/test_executor.cpp
@@ -45,17 +45,6 @@ using namespace std::string_literals;
 
 PYMRC_TEST_CLASS(Executor);
 
-TEST_F(TestExecutor, DGExecute)
-{
-    EXPECT_EQ(1, 1);
-    EXPECT_EQ(PyGILState_Check(), 1);
-    pymrc::PyHolder py_holder{};
-    EXPECT_FALSE(py_holder);
-
-    py_holder = pymrc::PyHolder{py::module::import("mrc")};
-    EXPECT_TRUE(py_holder);
-}
-
 TEST_F(TestExecutor, Execute)
 {
     std::atomic<unsigned int> counter = 0;

--- a/python/mrc/_pymrc/tests/test_executor.cpp
+++ b/python/mrc/_pymrc/tests/test_executor.cpp
@@ -19,6 +19,8 @@
 
 #include "pymrc/executor.hpp"
 #include "pymrc/pipeline.hpp"
+#include "pymrc/types.hpp"
+#include "pymrc/utilities/object_wrappers.hpp"
 
 #include "mrc/node/rx_node.hpp"
 #include "mrc/node/rx_sink.hpp"
@@ -42,6 +44,17 @@ namespace pymrc = mrc::pymrc;
 using namespace std::string_literals;
 
 PYMRC_TEST_CLASS(Executor);
+
+TEST_F(TestExecutor, DGExecute)
+{
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(PyGILState_Check(), 1);
+    pymrc::PyHolder py_holder{};
+    EXPECT_FALSE(py_holder);
+
+    py_holder = pymrc::PyHolder{py::module::import("mrc")};
+    EXPECT_TRUE(py_holder);
+}
 
 TEST_F(TestExecutor, Execute)
 {

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import typing
 
 import pytest
@@ -49,6 +50,9 @@ def configure_tests_logging(is_debugger_attached: bool):
     # Check if a debugger is attached. If so, choose DEBUG for the logging level. Otherwise, only WARN
     if (is_debugger_attached):
         log_level = logging.INFO
+
+    if os.environ.get("GLOG_v") is not None:
+        log_level = logging.DEBUG
 
     mrc_logging.init_logging("mrc_testing", py_level=log_level)
 

--- a/python/tests/test_executor.py
+++ b/python/tests/test_executor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import asyncio
+import os
+import time
 import typing
 
 import pytest
@@ -28,6 +30,53 @@ def pairwise(t):
 
 
 node_fn_type = typing.Callable[[mrc.Builder], mrc.SegmentObject]
+
+
+@pytest.fixture
+def source():
+
+    def build(builder: mrc.Builder):
+
+        def gen_data():
+            yield 1
+            yield 2
+            yield 3
+
+        return builder.make_source("source", gen_data)
+
+    return build
+
+
+@pytest.fixture
+def endless_source():
+
+    def build(builder: mrc.Builder):
+
+        def gen_data():
+            i = 0
+            while True:
+                yield i
+                i += 1
+                time.sleep(0.1)
+
+        return builder.make_source("endless_source", gen_data())
+
+    return build
+
+
+@pytest.fixture
+def blocking_source():
+
+    def build(builder: mrc.Builder):
+
+        def gen_data():
+            yield 1
+            while True:
+                time.sleep(0.1)
+
+        return builder.make_source("blocking_source", gen_data)
+
+    return build
 
 
 @pytest.fixture
@@ -65,12 +114,26 @@ def source_cppexception():
 
 
 @pytest.fixture
+def node_exception():
+
+    def build(builder: mrc.Builder):
+
+        def on_next(data):
+            print("Received value: {}".format(data), flush=True)
+            raise RuntimeError("unittest")
+
+        return builder.make_node("node", mrc.core.operators.map(on_next))
+
+    return build
+
+
+@pytest.fixture
 def sink():
 
     def build(builder: mrc.Builder):
 
         def sink_on_next(data):
-            print("Got value: {}".format(data))
+            print("Got value: {}".format(data), flush=True)
 
         return builder.make_sink("sink", sink_on_next, None, None)
 
@@ -111,7 +174,8 @@ def build_executor():
 
     def inner(pipe: mrc.Pipeline):
         options = mrc.Options()
-
+        options.topology.user_cpuset = f"0-{os.cpu_count() - 1}"
+        options.engine_factories.default_engine_type = mrc.core.options.EngineType.Thread
         executor = mrc.Executor(options)
         executor.register_pipeline(pipe)
 
@@ -181,6 +245,36 @@ def test_cppexception_in_source_async(source_cppexception: node_fn_type,
             await executor.join_async()
 
     asyncio.run(run_pipeline())
+
+
+@pytest.mark.parametrize("souce_name", ["source", "endless_source", "blocking_source"])
+def test_pyexception_in_node(source: node_fn_type,
+                             endless_source: node_fn_type,
+                             blocking_source: node_fn_type,
+                             node_exception: node_fn_type,
+                             build_pipeline: build_pipeline_type,
+                             build_executor: build_executor_type,
+                             souce_name: str):
+    """
+    Test to reproduce Morpheus issue #1838 where an exception raised in a node doesn't always shutdown the executor
+    when the source is intended to run indefinitely.
+    """
+
+    if souce_name == "endless_source":
+        source_fn = endless_source
+    elif souce_name == "blocking_source":
+        source_fn = blocking_source
+    else:
+        source_fn = source
+
+    pipe = build_pipeline(source_fn, node_exception)
+
+    executor: mrc.Executor = None
+
+    executor = build_executor(pipe)
+
+    with pytest.raises(RuntimeError):
+        executor.join()
 
 
 if (__name__ in ("__main__", )):


### PR DESCRIPTION
## Description
This is currently failing with on a Python Gil check on shutdown.

* Ensures that Python source nodes shutdown when their subscriber is unsubscribed
* Advance the underlying Python iterator inside of a `packaged_task` allowing the `PyIteratorIterator` to poll both the subscriber and the associated future.
* Fix out of date comment in `cpp/mrc/src/internal/service.hpp`
* Remove unused json usage in `python/mrc/_pymrc/src/utilities/acquire_gil.cpp`
* Update `conftest.py` to set the loglevel to `DEBUG` if the `GLOG_v` environment variable is defined.

This is part of nv-morpheus/Morpheus#1838

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
