### PR TITLE
Define a Python source which receives a reference to a subscriber

### DIFF
--- a/python/mrc/_pymrc/include/pymrc/segment.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/include/pymrc/segment.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment.hpp
@@ -143,7 +143,7 @@ class BuilderProxy
                                                                        const std::string& name,
                                                                        pybind11::function gen_factory);
 
-    static std::shared_ptr<mrc::segment::ObjectProperties> make_subscriber_source(mrc::segment::IBuilder& self,
+    static std::shared_ptr<mrc::segment::ObjectProperties> make_source_subscriber(mrc::segment::IBuilder& self,
                                                                                   const std::string& name,
                                                                                   pybind11::function gen_factory);
 

--- a/python/mrc/_pymrc/include/pymrc/segment.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment.hpp
@@ -143,10 +143,14 @@ class BuilderProxy
                                                                        const std::string& name,
                                                                        pybind11::function gen_factory);
 
-    static std::shared_ptr<mrc::segment::ObjectProperties> make_source(
-        mrc::segment::IBuilder& self,
-        const std::string& name,
-        const std::function<void(pymrc::PyObjectSubscriber& sub)>& f);
+    static std::shared_ptr<mrc::segment::ObjectProperties> make_subscriber_source(mrc::segment::IBuilder& self,
+                                                                                  const std::string& name,
+                                                                                  pybind11::function gen_factory);
+
+    // static std::shared_ptr<mrc::segment::ObjectProperties> make_source(
+    //     mrc::segment::IBuilder& self,
+    //     const std::string& name,
+    //     const std::function<void(pymrc::PyObjectSubscriber& sub)>& f);
 
     static std::shared_ptr<mrc::segment::ObjectProperties> make_source_component(mrc::segment::IBuilder& self,
                                                                                  const std::string& name,

--- a/python/mrc/_pymrc/include/pymrc/segment.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment.hpp
@@ -147,11 +147,6 @@ class BuilderProxy
                                                                                   const std::string& name,
                                                                                   pybind11::function gen_factory);
 
-    // static std::shared_ptr<mrc::segment::ObjectProperties> make_source(
-    //     mrc::segment::IBuilder& self,
-    //     const std::string& name,
-    //     const std::function<void(pymrc::PyObjectSubscriber& sub)>& f);
-
     static std::shared_ptr<mrc::segment::ObjectProperties> make_source_component(mrc::segment::IBuilder& self,
                                                                                  const std::string& name,
                                                                                  pybind11::iterator source_iterator);

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -320,17 +320,6 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
     py::function m_gen_factory{};
 };
 
-std::shared_ptr<mrc::segment::ObjectProperties> build_subscriber_source(mrc::segment::IBuilder& self,
-                                                                        const std::string& name,
-                                                                        py::function gen_factory)
-{
-    // auto wrapper = [gen_factory = std::move(gen_factory)](PyObjectSubscriber& subscriber) mutable {
-
-    // };
-
-    return self.construct_object<SubscriberFuncWrapper>(name, std::move(gen_factory));
-}
-
 std::shared_ptr<mrc::segment::ObjectProperties> build_source_component(mrc::segment::IBuilder& self,
                                                                        const std::string& name,
                                                                        PyIteratorWrapper iter_wrapper)
@@ -386,16 +375,8 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_subscriber_so
                                                                                      const std::string& name,
                                                                                      py::function gen_factory)
 {
-    return build_subscriber_source(self, name, std::move(gen_factory));
+    return self.construct_object<SubscriberFuncWrapper>(name, std::move(gen_factory));
 }
-
-// static std::shared_ptr<mrc::segment::ObjectProperties> make_source(
-//     mrc::segment::IBuilder& self,
-//     const std::string& name,
-//     const std::function<void(pymrc::PyObjectSubscriber& sub)>& f)
-// {
-//     return self.construct_object<PythonSource<PyHolder>>(name, f);
-// }
 
 std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source_component(mrc::segment::IBuilder& self,
                                                                                     const std::string& name,

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -271,7 +271,7 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
     {
         {
             AcquireGIL gil;
-            py::object kill = std::move(m_gen_factory);
+            PyFuncWrapper kill = std::move(m_gen_factory);
         }
     }
 
@@ -285,8 +285,8 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
             {
                 DVLOG(10) << ctx.info() << " Starting source";
                 py::gil_scoped_acquire gil;
-                py::object py_sub    = py::cast(subscriber);
-                py::iterator py_iter = py::cast<py::iterator>(m_gen_factory(std::move(py_sub)));
+                py::object py_sub = py::cast(subscriber);
+                auto py_iter      = m_gen_factory.operator()<py::iterator>(std::move(py_sub));
                 PyIteratorWrapper iter_wrapper{std::move(py_iter)};
 
                 for (auto next_val : iter_wrapper)
@@ -317,7 +317,7 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
         };
     }
 
-    py::function m_gen_factory{};
+    PyFuncWrapper m_gen_factory{};
 };
 
 std::shared_ptr<mrc::segment::ObjectProperties> build_source_component(mrc::segment::IBuilder& self,

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -267,14 +267,6 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
 
     SubscriberFuncWrapper(py::function gen_factory) : PythonSource(build()), m_gen_factory{std::move(gen_factory)} {}
 
-    ~SubscriberFuncWrapper() override
-    {
-        {
-            AcquireGIL gil;
-            PyFuncWrapper kill = std::move(m_gen_factory);
-        }
-    }
-
   private:
     subscriber_fn_t build()
     {

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -284,7 +284,7 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
             try
             {
                 DVLOG(10) << ctx.info() << " Starting source";
-                AcquireGIL gil;
+                py::gil_scoped_acquire gil;
                 py::object py_sub    = py::cast(subscriber);
                 py::iterator py_iter = py::cast<py::iterator>(m_gen_factory(std::move(py_sub)));
                 PyIteratorWrapper iter_wrapper{std::move(py_iter)};
@@ -294,6 +294,7 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
                     //  Only send if its subscribed. Very important to ensure the object has been moved!
                     if (subscriber.is_subscribed())
                     {
+                        py::gil_scoped_release no_gil;
                         subscriber.on_next(std::move(next_val));
                     }
                     else

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -363,7 +363,7 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source(mrc::s
     return build_source(self, name, PyIteratorWrapper(std::move(gen_factory)));
 }
 
-std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_subscriber_source(mrc::segment::IBuilder& self,
+std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source_subscriber(mrc::segment::IBuilder& self,
                                                                                      const std::string& name,
                                                                                      py::function gen_factory)
 {

--- a/python/mrc/core/segment.cpp
+++ b/python/mrc/core/segment.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/core/segment.cpp
+++ b/python/mrc/core/segment.cpp
@@ -134,6 +134,12 @@ PYBIND11_MODULE(segment, py_mod)
                                                                         const std::string&,
                                                                         py::function)>(&BuilderProxy::make_source));
 
+    Builder.def("make_subscriber_source",
+                static_cast<std::shared_ptr<mrc::segment::ObjectProperties> (*)(mrc::segment::IBuilder&,
+                                                                                const std::string&,
+                                                                                py::function)>(
+                    &BuilderProxy::make_subscriber_source));
+
     Builder.def("make_source_component",
                 static_cast<std::shared_ptr<mrc::segment::ObjectProperties> (*)(mrc::segment::IBuilder&,
                                                                                 const std::string&,

--- a/python/mrc/core/segment.cpp
+++ b/python/mrc/core/segment.cpp
@@ -134,11 +134,11 @@ PYBIND11_MODULE(segment, py_mod)
                                                                         const std::string&,
                                                                         py::function)>(&BuilderProxy::make_source));
 
-    Builder.def("make_subscriber_source",
+    Builder.def("make_source_subscriber",
                 static_cast<std::shared_ptr<mrc::segment::ObjectProperties> (*)(mrc::segment::IBuilder&,
                                                                                 const std::string&,
                                                                                 py::function)>(
-                    &BuilderProxy::make_subscriber_source));
+                    &BuilderProxy::make_source_subscriber));
 
     Builder.def("make_source_component",
                 static_cast<std::shared_ptr<mrc::segment::ObjectProperties> (*)(mrc::segment::IBuilder&,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import typing
 
 import pytest
@@ -49,6 +50,9 @@ def configure_tests_logging(is_debugger_attached: bool):
     # Check if a debugger is attached. If so, choose DEBUG for the logging level. Otherwise, only WARN
     if (is_debugger_attached):
         log_level = logging.INFO
+
+    if (os.environ.get('GLOG_v') is not None):
+        log_level = logging.DEBUG
 
     mrc_logging.init_logging("mrc_testing", py_level=log_level)
 

--- a/python/tests/test_executor.py
+++ b/python/tests/test_executor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/tests/test_executor.py
+++ b/python/tests/test_executor.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import asyncio
+import os
+import time
 import typing
 
 import pytest
@@ -28,6 +30,53 @@ def pairwise(t):
 
 
 node_fn_type = typing.Callable[[mrc.Builder], mrc.SegmentObject]
+
+
+@pytest.fixture
+def source():
+
+    def build(builder: mrc.Builder):
+
+        def gen_data():
+            yield 1
+            yield 2
+            yield 3
+
+        return builder.make_source("source", gen_data)
+
+    return build
+
+
+@pytest.fixture
+def endless_source():
+
+    def build(builder: mrc.Builder):
+
+        def gen_data():
+            i = 0
+            while True:
+                yield i
+                i += 1
+                time.sleep(0.1)
+
+        return builder.make_source("endless_source", gen_data())
+
+    return build
+
+
+@pytest.fixture
+def blocking_source():
+
+    def build(builder: mrc.Builder):
+
+        def gen_data(subscriber: mrc.Subscriber):
+            yield 1
+            while subscriber.is_subscribed():
+                time.sleep(0.1)
+
+        return builder.make_subscriber_source("blocking_source", gen_data)
+
+    return build
 
 
 @pytest.fixture
@@ -60,6 +109,21 @@ def source_cppexception():
             throw_cpp_error()
 
         return builder.make_source("source", gen_data_and_raise)
+
+    return build
+
+
+@pytest.fixture
+def node_exception():
+
+    def build(builder: mrc.Builder):
+
+        def on_next(data):
+            time.sleep(1)
+            print("Received value: {}".format(data), flush=True)
+            raise RuntimeError("unittest")
+
+        return builder.make_node("node", mrc.core.operators.map(on_next))
 
     return build
 
@@ -112,6 +176,8 @@ def build_executor():
     def inner(pipe: mrc.Pipeline):
         options = mrc.Options()
 
+        options.topology.user_cpuset = f"0-{os.cpu_count() - 1}"
+        options.engine_factories.default_engine_type = mrc.core.options.EngineType.Thread
         executor = mrc.Executor(options)
         executor.register_pipeline(pipe)
 
@@ -181,6 +247,36 @@ def test_cppexception_in_source_async(source_cppexception: node_fn_type,
             await executor.join_async()
 
     asyncio.run(run_pipeline())
+
+
+@pytest.mark.parametrize("souce_name", ["source", "endless_source", "blocking_source"])
+def test_pyexception_in_node(source: node_fn_type,
+                             endless_source: node_fn_type,
+                             blocking_source: node_fn_type,
+                             node_exception: node_fn_type,
+                             build_pipeline: build_pipeline_type,
+                             build_executor: build_executor_type,
+                             souce_name: str):
+    """
+    Test to reproduce Morpheus issue #1838 where an exception raised in a node doesn't always shutdown the executor
+    when the source is intended to run indefinitely.
+    """
+
+    if souce_name == "endless_source":
+        source_fn = endless_source
+    elif souce_name == "blocking_source":
+        source_fn = blocking_source
+    else:
+        source_fn = source
+
+    pipe = build_pipeline(source_fn, node_exception)
+
+    executor: mrc.Executor = None
+
+    executor = build_executor(pipe)
+
+    with pytest.raises(RuntimeError):
+        executor.join()
 
 
 if (__name__ in ("__main__", )):

--- a/python/tests/test_executor.py
+++ b/python/tests/test_executor.py
@@ -74,7 +74,7 @@ def blocking_source():
             while subscriber.is_subscribed():
                 time.sleep(0.1)
 
-        return builder.make_subscriber_source("blocking_source", gen_data)
+        return builder.make_source_subscriber("blocking_source", gen_data)
 
     return build
 


### PR DESCRIPTION
## Description
* Allows a Python generator source to check if the subscriber is still subscribed.
* Define a class `SubscriberFuncWrapper`  for Python sources rather than just a lambda. The reason is that python objects captured by the lambda need to be destroyed while the gil is held, which causes a problem if the lambda is destroyed unexpectedly.
* Update `conftest.py` to set the loglevel to `DEBUG` if the `GLOG_v` environment variable is defined.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
