### PR TITLE
Pass a `mrc.Subscription` object to sources rather than a `mrc.Subscriber`

### DIFF
--- a/python/mrc/_pymrc/include/pymrc/segment.hpp
+++ b/python/mrc/_pymrc/include/pymrc/segment.hpp
@@ -143,10 +143,6 @@ class BuilderProxy
                                                                        const std::string& name,
                                                                        pybind11::function gen_factory);
 
-    static std::shared_ptr<mrc::segment::ObjectProperties> make_source_subscriber(mrc::segment::IBuilder& self,
-                                                                                  const std::string& name,
-                                                                                  pybind11::function gen_factory);
-
     static std::shared_ptr<mrc::segment::ObjectProperties> make_source_component(mrc::segment::IBuilder& self,
                                                                                  const std::string& name,
                                                                                  pybind11::iterator source_iterator);

--- a/python/mrc/_pymrc/include/pymrc/subscriber.hpp
+++ b/python/mrc/_pymrc/include/pymrc/subscriber.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,12 @@ class SubscriberProxy
     static void on_next(PyObjectSubscriber* self, pybind11::object&& value);
     static void on_error(PyObjectSubscriber* self, pybind11::object&& value);
     static bool is_subscribed(PyObjectSubscriber* self);
+};
+
+class SubscriptionProxy
+{
+  public:
+    static bool is_subscribed(PySubscription* self);
 };
 
 class ObservableProxy

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -277,9 +277,9 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
             {
                 DVLOG(10) << ctx.info() << " Starting source";
                 py::gil_scoped_acquire gil;
-                auto subscription = subscriber.get_subscription();
-                py::object py_sub = py::cast(subscription);
-                auto py_iter      = m_gen_factory.operator()<py::iterator>(std::move(py_sub));
+                PySubscription subscription = subscriber.get_subscription();
+                py::object py_sub           = py::cast(subscription);
+                auto py_iter                = m_gen_factory.operator()<py::iterator>(std::move(py_sub));
                 PyIteratorWrapper iter_wrapper{std::move(py_iter)};
 
                 for (auto next_val : iter_wrapper)

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -376,7 +376,7 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source(mrc::s
         return build_source(self, name, PyIteratorWrapper(std::move(gen_factory)));
     }
 
-    throw std::runtime_error("Invalid number of parameters for source generator function. Expected 0 or 1");
+    throw py::value_error("Invalid number of parameters for source generator function. Expected 0 or 1");
 }
 
 std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source_component(mrc::segment::IBuilder& self,

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -362,9 +362,10 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source(mrc::s
                                                                           py::function gen_factory)
 {
     // Determine if the gen_factory is expecting to receive a subscription object
-    auto inspect_mod = py::module::import("inspect");
-    auto signature   = inspect_mod.attr("signature")(gen_factory);
-    auto num_params  = py::len(signature.attr("parameters"));
+    auto inspect_mod          = py::module::import("inspect");
+    auto signature            = inspect_mod.attr("signature")(gen_factory);
+    auto num_params           = py::len(signature.attr("parameters"));
+    bool expects_subscription = false;
 
     if (num_params == 1)
     {
@@ -375,8 +376,6 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source(mrc::s
     {
         return build_source(self, name, PyIteratorWrapper(std::move(gen_factory)));
     }
-
-    throw py::value_error("Invalid number of parameters for source generator function. Expected 0 or 1");
 }
 
 std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source_component(mrc::segment::IBuilder& self,

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -277,7 +277,8 @@ class SubscriberFuncWrapper : public mrc::pymrc::PythonSource<PyHolder>
             {
                 DVLOG(10) << ctx.info() << " Starting source";
                 py::gil_scoped_acquire gil;
-                py::object py_sub = py::cast(subscriber);
+                auto subscription = subscriber.get_subscription();
+                py::object py_sub = py::cast(subscription);
                 auto py_iter      = m_gen_factory.operator()<py::iterator>(std::move(py_sub));
                 PyIteratorWrapper iter_wrapper{std::move(py_iter)};
 

--- a/python/mrc/_pymrc/src/segment.cpp
+++ b/python/mrc/_pymrc/src/segment.cpp
@@ -364,18 +364,30 @@ std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source(mrc::s
     // Determine if the gen_factory is expecting to receive a subscription object
     auto inspect_mod          = py::module::import("inspect");
     auto signature            = inspect_mod.attr("signature")(gen_factory);
-    auto num_params           = py::len(signature.attr("parameters"));
+    auto params               = signature.attr("parameters");
+    auto num_params           = py::len(params);
     bool expects_subscription = false;
 
-    if (num_params == 1)
+    if (num_params > 0)
+    {
+        // We know there is at least one parameter. Check if the first parameter is a subscription object
+        // Note, when we receive a function that has been bound with `functools.partial(fn, arg1=some_value)`, the
+        // parameter is still visible in the signature of the partial object.
+        auto mrc_mod         = py::module::import("mrc");
+        auto param_values    = params.attr("values")();
+        auto first_param     = py::iter(param_values);
+        auto type_hint       = py::object((*first_param).attr("annotation"));
+        expects_subscription = (type_hint.is(mrc_mod.attr("Subscription")) ||
+                                type_hint.equal(py::str("mrc.Subscription")) ||
+                                type_hint.equal(py::str("Subscription")));
+    }
+
+    if (expects_subscription)
     {
         return self.construct_object<SubscriberFuncWrapper>(name, std::move(gen_factory));
     }
 
-    if (num_params == 0)
-    {
-        return build_source(self, name, PyIteratorWrapper(std::move(gen_factory)));
-    }
+    return build_source(self, name, PyIteratorWrapper(std::move(gen_factory)));
 }
 
 std::shared_ptr<mrc::segment::ObjectProperties> BuilderProxy::make_source_component(mrc::segment::IBuilder& self,

--- a/python/mrc/_pymrc/src/subscriber.cpp
+++ b/python/mrc/_pymrc/src/subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,12 @@ void SubscriberProxy::on_error(PyObjectSubscriber* self, py::object&& value)
 };
 
 bool SubscriberProxy::is_subscribed(PyObjectSubscriber* self)
+{
+    // No GIL here
+    return self->is_subscribed();
+}
+
+bool SubscriptionProxy::is_subscribed(PySubscription* self)
 {
     // No GIL here
     return self->is_subscribed();

--- a/python/mrc/core/segment.cpp
+++ b/python/mrc/core/segment.cpp
@@ -134,12 +134,6 @@ PYBIND11_MODULE(segment, py_mod)
                                                                         const std::string&,
                                                                         py::function)>(&BuilderProxy::make_source));
 
-    Builder.def("make_source_subscriber",
-                static_cast<std::shared_ptr<mrc::segment::ObjectProperties> (*)(mrc::segment::IBuilder&,
-                                                                                const std::string&,
-                                                                                py::function)>(
-                    &BuilderProxy::make_source_subscriber));
-
     Builder.def("make_source_component",
                 static_cast<std::shared_ptr<mrc::segment::ObjectProperties> (*)(mrc::segment::IBuilder&,
                                                                                 const std::string&,

--- a/python/mrc/core/subscriber.cpp
+++ b/python/mrc/core/subscriber.cpp
@@ -50,7 +50,8 @@ PYBIND11_MODULE(subscriber, py_mod)
     // Common must be first in every module
     pymrc::import(py_mod, "mrc.core.common");
 
-    py::class_<PySubscription>(py_mod, "Subscription");
+    py::class_<PySubscription>(py_mod, "Subscription")
+        .def("is_subscribed", &SubscriptionProxy::is_subscribed, py::call_guard<py::gil_scoped_release>());
 
     py::class_<PyObjectObserver>(py_mod, "Observer")
         .def("on_next",

--- a/python/tests/test_executor.py
+++ b/python/tests/test_executor.py
@@ -69,9 +69,9 @@ def blocking_source():
 
     def build(builder: mrc.Builder):
 
-        def gen_data(subscriber: mrc.Subscriber):
+        def gen_data(subscription: mrc.Subscription):
             yield 1
-            while subscriber.is_subscribed():
+            while subscription.is_subscribed():
                 time.sleep(0.1)
 
         return builder.make_source_subscriber("blocking_source", gen_data)

--- a/python/tests/test_executor.py
+++ b/python/tests/test_executor.py
@@ -74,7 +74,7 @@ def blocking_source():
             while subscription.is_subscribed():
                 time.sleep(0.1)
 
-        return builder.make_source_subscriber("blocking_source", gen_data)
+        return builder.make_source("blocking_source", gen_data)
 
     return build
 

--- a/python/tests/test_node.py
+++ b/python/tests/test_node.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/tests/test_node.py
+++ b/python/tests/test_node.py
@@ -489,5 +489,26 @@ def test_sink_function_unpacking(single_segment_pipeline, node_type: str, use_pa
     assert on_completed_count == 1
 
 
+def test_invalid_source():
+
+    def segment_init(seg: mrc.Builder):
+
+        def source_gen(a, b):
+            yield a + b
+
+        seg.make_source("my_src", source_gen)
+
+    pipeline = mrc.Pipeline()
+    pipeline.make_segment("my_seg", segment_init)
+
+    options = mrc.Options()
+    executor = mrc.Executor(options)
+    executor.register_pipeline(pipeline)
+
+    with pytest.raises(ValueError):
+        executor.start()
+        executor.join()
+
+
 if (__name__ == "__main__"):
     test_launch_options_properties()

--- a/python/tests/test_node.py
+++ b/python/tests/test_node.py
@@ -489,27 +489,6 @@ def test_sink_function_unpacking(single_segment_pipeline, node_type: str, use_pa
     assert on_completed_count == 1
 
 
-def test_invalid_source():
-
-    def segment_init(seg: mrc.Builder):
-
-        def source_gen(a, b):
-            yield a + b
-
-        seg.make_source("my_src", source_gen)
-
-    pipeline = mrc.Pipeline()
-    pipeline.make_segment("my_seg", segment_init)
-
-    options = mrc.Options()
-    executor = mrc.Executor(options)
-    executor.register_pipeline(pipeline)
-
-    with pytest.raises(ValueError):
-        executor.start()
-        executor.join()
-
-
 def test_source_with_bound_value():
     """
     This test ensures that the bound values isn't confused with a subscription object


### PR DESCRIPTION
## Description
* Remove the `make_source_subscriber` method in favor of inspecting the Python function signature.
* Since the `make_source_subscriber` method was never part of a release I think this can still be considered a non-breaking change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
