### PR TITLE
Fix Incorrect docstring in `mrc.core.coro`

### DIFF
--- a/python/mrc/_pymrc/include/pymrc/coro.hpp
+++ b/python/mrc/_pymrc/include/pymrc/coro.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@
 #include <mrc/coroutines/task.hpp>
 #include <mrc/utils/string_utils.hpp>
 #include <pybind11/cast.h>
-#include <pybind11/detail/descr.h>
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>

--- a/python/mrc/core/coro.cpp
+++ b/python/mrc/core/coro.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/core/coro.cpp
+++ b/python/mrc/core/coro.cpp
@@ -16,8 +16,10 @@
  */
 #include "pymrc/coro.hpp"
 
+#include "mrc/coroutines/task.hpp"
+#include "mrc/version.hpp"
+
 #include <glog/logging.h>
-#include <mrc/coroutines/task.hpp>
 #include <pybind11/gil.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -36,7 +38,7 @@ PYBIND11_MODULE(coro, _module)
 {
     _module.doc() = R"pbdoc(
         -----------------------
-        .. currentmodule:: morpheus.llm
+        .. currentmodule:: coro
         .. autosummary::
            :toctree: _generate
 
@@ -61,7 +63,7 @@ PYBIND11_MODULE(coro, _module)
         co_return strings[0];
     });
 
-    // _module.attr("__version__") =
-    //     MRC_CONCAT_STR(morpheus_VERSION_MAJOR << "." << morpheus_VERSION_MINOR << "." << morpheus_VERSION_PATCH);
+    _module.attr("__version__") = MRC_CONCAT_STR(mrc_VERSION_MAJOR << "." << mrc_VERSION_MINOR << "."
+                                                                   << mrc_VERSION_PATCH);
 }
 }  // namespace mrc::pymrc::coro

--- a/python/mrc/core/executor.cpp
+++ b/python/mrc/core/executor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/core/executor.cpp
+++ b/python/mrc/core/executor.cpp
@@ -32,7 +32,7 @@
 #include <sstream>
 #include <utility>  // for move
 
-// IWYU thinks we need vectir for py::class_<Executor, std::shared_ptr<Executor>>
+// IWYU thinks we need vector for py::class_<Executor, std::shared_ptr<Executor>>
 // IWYU pragma: no_include <vector>
 
 namespace mrc::pymrc {


### PR DESCRIPTION
## Description
* Include MRC libs with quotes not <>
* Add MRC version string to coro module (all the other Python modules have this)
* Fix spelling mistake in a comment in `python/mrc/core/executor.cpp`

Closes [#492](https://github.com/nv-morpheus/MRC/issues/492)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
