### PR TITLE
devcontainer: replace VAULT_HOST with AWS_ROLE_ARN

### DIFF
--- a/.devcontainer/conda/Dockerfile
+++ b/.devcontainer/conda/Dockerfile
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rapidsai/devcontainers:23.04-cuda12.1-mambaforge-ubuntu22.04 AS base
+FROM rapidsai/devcontainers:24.12-cuda12.1-mambaforge-ubuntu22.04 AS base
 
 ENV PATH="${PATH}:/workspaces/mrc/.devcontainer/bin"

--- a/.devcontainer/conda/devcontainer.json
+++ b/.devcontainer/conda/devcontainer.json
@@ -35,7 +35,7 @@
         "MRC_ROOT": "${containerWorkspaceFolder}",
         "DEFAULT_CONDA_ENV": "mrc",
         "MAMBA_NO_BANNER": "1",
-        "VAULT_HOST": "https://vault.ops.k8s.rapids.ai"
+        "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs"
     },
     "initializeCommand": [ "${localWorkspaceFolder}/.devcontainer/conda/initialize-command.sh" ],
     "remoteUser": "coder",

--- a/.devcontainer/opt/mrc/conda/Dockerfile
+++ b/.devcontainer/opt/mrc/conda/Dockerfile
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rapidsai/devcontainers:23.04-cuda12.1-mambaforge-ubuntu22.04 AS base
+FROM rapidsai/devcontainers:24.12-cuda12.1-mambaforge-ubuntu22.04 AS base
 
 ENV PATH="${PATH}:/workspaces/mrc/.devcontainer/bin"

--- a/.devcontainer/opt/mrc/conda/devcontainer.json
+++ b/.devcontainer/opt/mrc/conda/devcontainer.json
@@ -35,7 +35,7 @@
         "MRC_ROOT": "${containerWorkspaceFolder}",
         "DEFAULT_CONDA_ENV": "mrc",
         "MAMBA_NO_BANNER": "1",
-        "VAULT_HOST": "https://vault.ops.k8s.rapids.ai"
+        "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs"
     },
     "initializeCommand": [ "${localWorkspaceFolder}/.devcontainer/initialize-command.sh" ],
     "remoteUser": "coder",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR is replacing the `VAULT_HOST` variable with `AWS_ROLE_ARN`. This is required to use the new token service to get AWS credentials

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
