### PR TITLE
Update pybind11-stubgen to v2.4.2

### DIFF
--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     - librmm {{ rapids_version }}
     - nlohmann_json =3.11
     - pybind11-abi # See: https://conda-forge.org/docs/maintainer/knowledge_base.html#pybind11-abi-constraints
-    - pybind11-stubgen =0.10
+    - pybind11-stubgen =2.4.2
     - python {{ python }}
     - scikit-build =0.17
     - ucx =1.15

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - numpy=1.24
 - pkg-config=0.29
 - pre-commit
-- pybind11-stubgen=0.10
+- pybind11-stubgen=2.4.2
 - pytest
 - pytest-asyncio
 - pytest-timeout

--- a/conda/environments/ci_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/ci_cuda-125_arch-x86_64.yaml
@@ -32,7 +32,7 @@ dependencies:
 - numactl=2.0.18
 - pkg-config=0.29
 - pre-commit
-- pybind11-stubgen=0.10
+- pybind11-stubgen=2.4.2
 - pytest
 - pytest-asyncio
 - pytest-timeout

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ dependencies:
           - nlohmann_json=3.11
           - numactl=2.0.18
           - pkg-config=0.29
-          - pybind11-stubgen=0.10
+          - pybind11-stubgen=2.4.2
           - scikit-build=0.17
           - ucx=1.15
 


### PR DESCRIPTION
## Description
Requires https://github.com/nv-morpheus/utilities/pull/89 to be merged first

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
