### PR TITLE
Fix bug where `AsyncioRunnable` hangs if `process_one` throws and the source is not emitting new values

### DIFF
--- a/cpp/mrc/include/mrc/edge/edge_channel.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_channel.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "mrc/channel/types.hpp"  // for time_point_t
 #include "mrc/edge/edge_readable.hpp"
 #include "mrc/edge/edge_writable.hpp"
 #include "mrc/edge/forward.hpp"
@@ -43,6 +44,11 @@ class EdgeChannelReader : public IEdgeReadable<T>
     virtual channel::Status await_read(T& t)
     {
         return m_channel->await_read(t);
+    }
+
+    virtual channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp)
+    {
+        return m_channel->await_read_until(t, tp);
     }
 
   private:

--- a/cpp/mrc/include/mrc/edge/edge_readable.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_readable.hpp
@@ -62,11 +62,8 @@ class IEdgeReadable : public virtual Edge<T>, public IEdgeReadableBase
         return EdgeTypeInfo::create<T>();
     }
 
-    virtual channel::Status await_read(T& t) = 0;
-    virtual channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp)
-    {
-        throw std::runtime_error("Not implemented");
-    };
+    virtual channel::Status await_read(T& t)                                             = 0;
+    virtual channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) = 0;
 };
 
 template <typename InputT, typename OutputT = InputT>

--- a/cpp/mrc/include/mrc/edge/edge_readable.hpp
+++ b/cpp/mrc/include/mrc/edge/edge_readable.hpp
@@ -20,6 +20,7 @@
 #include "mrc/channel/channel.hpp"
 #include "mrc/channel/egress.hpp"
 #include "mrc/channel/ingress.hpp"
+#include "mrc/channel/types.hpp"  // for time_point_t
 #include "mrc/edge/edge.hpp"
 #include "mrc/exceptions/runtime_error.hpp"
 #include "mrc/node/forward.hpp"
@@ -62,6 +63,7 @@ class IEdgeReadable : public virtual Edge<T>, public IEdgeReadableBase
     }
 
     virtual channel::Status await_read(T& t) = 0;
+    // virtual channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) = 0;
 };
 
 template <typename InputT, typename OutputT = InputT>

--- a/cpp/mrc/include/mrc/node/sink_properties.hpp
+++ b/cpp/mrc/include/mrc/node/sink_properties.hpp
@@ -43,6 +43,13 @@ class NullReadableEdge : public edge::IEdgeReadable<T>
 
         return channel::Status::error;
     }
+
+    channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) override
+    {
+        throw std::runtime_error("Attempting to read from a null edge. Ensure an edge was established for all sinks.");
+
+        return channel::Status::error;
+    }
 };
 
 /**

--- a/cpp/mrc/include/mrc/node/sink_properties.hpp
+++ b/cpp/mrc/include/mrc/node/sink_properties.hpp
@@ -40,15 +40,11 @@ class NullReadableEdge : public edge::IEdgeReadable<T>
     channel::Status await_read(T& t) override
     {
         throw std::runtime_error("Attempting to read from a null edge. Ensure an edge was established for all sinks.");
-
-        return channel::Status::error;
     }
 
     channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) override
     {
         throw std::runtime_error("Attempting to read from a null edge. Ensure an edge was established for all sinks.");
-
-        return channel::Status::error;
     }
 };
 

--- a/cpp/mrc/include/mrc/node/source_properties.hpp
+++ b/cpp/mrc/include/mrc/node/source_properties.hpp
@@ -288,6 +288,11 @@ class ForwardingReadableProvider : public ReadableProvider<T>
             return m_parent.get_next(t);
         }
 
+        channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) override
+        {
+            throw std::runtime_error("Not implemented");
+        }
+
       private:
         ForwardingReadableProvider<T>& m_parent;
     };

--- a/cpp/mrc/tests/node/test_nodes.hpp
+++ b/cpp/mrc/tests/node/test_nodes.hpp
@@ -118,7 +118,6 @@ class EdgeReadableLambda : public edge::IEdgeReadable<T>
     channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) override
     {
         throw std::runtime_error("Not implemented");
-        return channel::Status::error;
     }
 
   private:

--- a/cpp/mrc/tests/node/test_nodes.hpp
+++ b/cpp/mrc/tests/node/test_nodes.hpp
@@ -115,6 +115,12 @@ class EdgeReadableLambda : public edge::IEdgeReadable<T>
         return m_on_await_read(t);
     }
 
+    channel::Status await_read_until(T& t, const mrc::channel::time_point_t& tp) override
+    {
+        throw std::runtime_error("Not implemented");
+        return channel::Status::error;
+    }
+
   private:
     std::function<channel::Status(T&)> m_on_await_read;
     std::function<void()> m_on_complete;

--- a/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
+++ b/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
@@ -29,6 +29,7 @@
 #include <mrc/coroutines/closable_ring_buffer.hpp>
 #include <mrc/coroutines/task.hpp>
 #include <mrc/coroutines/task_container.hpp>
+#include <mrc/edge/edge_channel.hpp>  // for EdgeChannelReader
 #include <mrc/exceptions/exception_catcher.hpp>
 #include <mrc/node/sink_properties.hpp>
 #include <mrc/runnable/forward.hpp>
@@ -118,8 +119,17 @@ class AsyncSink : public mrc::node::WritableProvider<T>,
 {
   protected:
     AsyncSink() :
-      m_read_async([this](T& value) {
-          return this->get_readable_edge()->await_read(value);
+      m_read_async([this](T& value, std::stop_source& stop_source) {
+          using namespace std::chrono_literals;
+          auto edge              = std::static_pointer_cast<edge::EdgeChannelReader<T>>(this->get_readable_edge());
+          channel::Status status = channel::Status::timeout;
+          while ((status == channel::Status::timeout || status == channel::Status::empty) &&
+                 not stop_source.stop_requested())
+          {
+              status = edge->await_read_until(value, std::chrono::system_clock::now() + 10ms);
+          }
+
+          return status;
       })
     {
         // Set the default channel
@@ -129,13 +139,13 @@ class AsyncSink : public mrc::node::WritableProvider<T>,
     /**
      * @brief Asynchronously reads a value from the sink's channel
      */
-    coroutines::Task<mrc::channel::Status> read_async(T& value)
+    coroutines::Task<mrc::channel::Status> read_async(T& value, std::stop_source& stop_source)
     {
-        co_return co_await m_read_async(std::ref(value));
+        co_return co_await m_read_async(std::ref(value), std::ref(stop_source));
     }
 
   private:
-    BoostFutureAwaitableOperation<mrc::channel::Status(T&)> m_read_async;
+    BoostFutureAwaitableOperation<mrc::channel::Status(T&, std::stop_source&)> m_read_async;
 };
 
 /**
@@ -297,8 +307,8 @@ coroutines::Task<> AsyncioRunnable<InputT, OutputT>::main_task(std::shared_ptr<m
     {
         InputT data;
 
-        auto read_status = co_await this->read_async(data);
-
+        mrc::channel::Status read_status = mrc::channel::Status::success;
+        read_status                      = co_await this->read_async(data, m_stop_source);
         if (read_status != mrc::channel::Status::success)
         {
             break;
@@ -309,6 +319,7 @@ coroutines::Task<> AsyncioRunnable<InputT, OutputT>::main_task(std::shared_ptr<m
 
     co_await outstanding_tasks.garbage_collect_and_yield_until_empty();
 
+    // this is a no-op if there are no exceptions
     catcher.rethrow_next_exception();
 }
 
@@ -339,6 +350,7 @@ coroutines::Task<> AsyncioRunnable<InputT, OutputT>::process_one(InputT value,
     } catch (...)
     {
         catcher.push_exception(std::current_exception());
+        on_state_update(state_t::Kill);
     }
 }
 

--- a/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
+++ b/python/mrc/_pymrc/include/pymrc/asyncio_runnable.hpp
@@ -121,7 +121,7 @@ class AsyncSink : public mrc::node::WritableProvider<T>,
     AsyncSink() :
       m_read_async([this](T& value, std::stop_source& stop_source) {
           using namespace std::chrono_literals;
-          auto edge              = std::static_pointer_cast<edge::EdgeChannelReader<T>>(this->get_readable_edge());
+          auto edge              = this->get_readable_edge();
           channel::Status status = channel::Status::timeout;
           while ((status == channel::Status::timeout || status == channel::Status::empty) &&
                  not stop_source.stop_requested())

--- a/python/mrc/_pymrc/include/pymrc/node.hpp
+++ b/python/mrc/_pymrc/include/pymrc/node.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/python/mrc/_pymrc/tests/test_asyncio_runnable.cpp
+++ b/python/mrc/_pymrc/tests/test_asyncio_runnable.cpp
@@ -104,6 +104,11 @@ class __attribute__((visibility("default"))) PythonCallbackAsyncioRunnable : pub
             result = co_await pymrc::coro::PyTaskToCppAwaitable(std::move(coroutine));
         }
 
+        if (result.is_none())
+        {
+            co_return;
+        }
+
         auto result_casted = py::cast<int>(result);
 
         py::gil_scoped_release release;

--- a/python/mrc/_pymrc/tests/test_asyncio_runnable.cpp
+++ b/python/mrc/_pymrc/tests/test_asyncio_runnable.cpp
@@ -373,10 +373,6 @@ TEST_F(TestAsyncioRunnable, UseAsyncioTasksThrows2086)
                 boost::this_fiber::sleep_for(10ms);
 
                 ++i;
-                if (i == 2)
-                {
-                    DVLOG(1) << "source finished emitting values";
-                }
             }
 
             s.on_completed();


### PR DESCRIPTION
## Description
* Fixes a bug first observed in [NVIDIA-AI-Blueprints/vulnerability-analysis](https://github.com/NVIDIA-AI-Blueprints/vulnerability-analysis) and reported in nv-morpheus/Morpheus#2086
* `AsyncioRunnable` will now call `on_state_update(state_t::Kill)` when an exception is caught
* Replace blocking call to `await_read` with `await_read_until` allowing `AsyncioRunnable` to check `stop_source.stop_requested()` 
* Define new `await_read_until` method in `IEdgeReadable`, unfortunately this interface has numerous subclasses which all then needed new `await_read_until` methods, even though `EdgeChannelReader` is the only class that really needed it. Alternatives:
  - In `AsyncSink` perform a static cast of `this->get_readable_edge()` to `EdgeChannelReader`
  - Define `await_read_until` method in `IEdgeReadable` but give it an implementation that throws a non-impl exception (or asserts false)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
