### PR TITLE
[chore] Suppress innocent warning with clang; add simple CMakePresets.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts")
   endif()
 
+  # Suppress unused argument during compilation due to -L being included
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
 endif()
 
 # Now enable CUDA

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,187 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 24,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "debug",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },{
+            "name": "release",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "name": "base",
+            "hidden": true,
+            "binaryDir": "build",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_MESSAGE_CONTEXT_SHOW": "ON",
+                
+                "MRC_USE_CONDA": "ON",
+                "MRC_USE_IWYU": "OFF",
+
+                "MRC_BUILD_DOCS": "OFF",
+                
+                "MRC_BUILD_TESTS": "ON",
+                "MRC_BUILD_BENCHMARKS": "ON",
+                
+                "MRC_BUILD_PYTHON": "ON",
+                "MRC_PYTHON_PERFORM_INSTALL" : "ON"
+            }
+        },
+        {
+            "name": "clang",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++"
+            }
+        },
+        {
+            "name": "gcc-debug",
+            "inherits": ["base", "debug"]
+        },
+        {
+            "name": "clang-debug",
+            "inherits": ["base", "debug", "clang"]
+        },
+        {
+            "name": "gcc-release",
+            "inherits": ["base", "release"]
+        },
+        {
+            "name": "clang-release",
+            "inherits": ["base", "release", "clang"]
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "gcc-debug",
+            "configurePreset": "gcc-debug"
+        },
+        {
+            "name": "clang-debug",
+            "configurePreset": "clang-debug"
+        },
+        {
+            "name": "gcc-release",
+            "configurePreset": "gcc-release"
+        },
+        {
+            "name": "clang-release",
+            "configurePreset": "clang-release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "noTestsAction": "error",
+                "stopOnFailure": false
+            }
+        },
+        {
+            "name": "gcc-debug",
+            "inherits": "base",
+            "configurePreset": "gcc-debug"
+        },
+        {
+            "name": "gcc-release",
+            "inherits": "base",
+            "configurePreset": "gcc-release"
+        },
+        {
+            "name": "clang-debug",
+            "inherits": "base",
+            "configurePreset": "clang-debug"
+        },
+        {
+            "name": "clang-release",
+            "inherits": "base",
+            "configurePreset": "clang-release"
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "gcc-debug",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "gcc-debug"
+                },
+                {
+                    "type": "build",
+                    "name": "gcc-debug"
+                },
+                {
+                    "type": "test",
+                    "name": "gcc-debug"
+                }
+            ]
+        },
+        {
+            "name": "clang-debug",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "clang-debug"
+                },
+                {
+                    "type": "build",
+                    "name": "clang-debug"
+                },
+                {
+                    "type": "test",
+                    "name": "clang-debug"
+                }
+            ]
+        },
+        {
+            "name": "gcc-release",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "gcc-release"
+                },
+                {
+                    "type": "build",
+                    "name": "gcc-release"
+                },
+                {
+                    "type": "test",
+                    "name": "gcc-release"
+                }
+            ]
+        },
+        {
+            "name": "clang-release",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "clang-release"
+                },
+                {
+                    "type": "build",
+                    "name": "clang-release"
+                },
+                {
+                    "type": "test",
+                    "name": "clang-release"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Description

1. Currently, CMake adds `-L` flags to compiling object files. GCC does not warn about this, but Clang does. Suppress the noise with `-Wno-unused-command-line-argument`.

2. `CMakePresets.json` are relatively recent but allow you to easily kick off a CMake configure/build/test (or combination of all via workflow). Add an initial (opinionated) configuration that offers four options:
  * gcc-debug
  * gcc-release
  * clang-debug
  * clang-release

The advantage here is the end user doesn't have to remember a bunch of flags to pass to CMake. They can just invoke via: `cmake --workflow --preset gcc-debug`. This also offers better IDE integration, particularly in VSCode.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
