### PR TITLE
Add missing test dependencies for Conda builds

### DIFF
--- a/ci/conda/recipes/libmrc/meta.yaml
+++ b/ci/conda/recipes/libmrc/meta.yaml
@@ -140,6 +140,8 @@ outputs:
         - numpy
         - nvtx
         - pytest
+        - pytest-asyncio
+        - pytest-timeout
         - cuml {{ rapids_version }}.* # Ensure we can install cuml. This can cause issues solving libabseil
 
 about:

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -124,7 +124,7 @@ function fetch_base_branch_gh_api() {
 
 function fetch_base_branch_local() {
     rapids-logger "Retrieving base branch from git"
-    git remote set-url upstream ${GIT_UPSTREAM_URL}
+    git remote add upstream ${GIT_UPSTREAM_URL}
     git fetch upstream --tags
     source ${MRC_ROOT}/ci/scripts/common.sh
     export BASE_BRANCH=$(get_base_branch)

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -124,7 +124,17 @@ function fetch_base_branch_gh_api() {
 
 function fetch_base_branch_local() {
     rapids-logger "Retrieving base branch from git"
-    git remote add upstream ${GIT_UPSTREAM_URL}
+
+    # In some workflows this is called more than once
+    set +e
+    git remote  | grep -q upstream
+    UPSTREAM_EXIT_STATUS=$?
+    set -e
+
+    if [[ "${UPSTREAM_EXIT_STATUS}" == "1" ]]; then
+        git remote add upstream ${GIT_UPSTREAM_URL}
+    fi
+
     git fetch upstream --tags
     source ${MRC_ROOT}/ci/scripts/common.sh
     export BASE_BRANCH=$(get_base_branch)

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -124,7 +124,6 @@ function fetch_base_branch_gh_api() {
 
 function fetch_base_branch_local() {
     rapids-logger "Retrieving base branch from git"
-    git remote add upstream ${GIT_UPSTREAM_URL}
     git fetch upstream --tags
     source ${MRC_ROOT}/ci/scripts/common.sh
     export BASE_BRANCH=$(get_base_branch)

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -124,6 +124,7 @@ function fetch_base_branch_gh_api() {
 
 function fetch_base_branch_local() {
     rapids-logger "Retrieving base branch from git"
+    git remote set-url upstream ${GIT_UPSTREAM_URL}
     git fetch upstream --tags
     source ${MRC_ROOT}/ci/scripts/common.sh
     export BASE_BRANCH=$(get_base_branch)


### PR DESCRIPTION
## Description
* Python tests depend on `pytest-asyncio`
* Fix local CI bug

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
