### PR TITLE
Disable the test_mrc_benchmarking set of tests in CI

### DIFF
--- a/ci/scripts/github/test.sh
+++ b/ci/scripts/github/test.sh
@@ -43,8 +43,11 @@ cmake -B build -G Ninja ${CMAKE_BUILD_ALL_FEATURES} .
 
 rapids-logger "Running C++ Tests"
 cd ${MRC_ROOT}/build
+
+# Exclude test_mrc_benchmarking to work-around #554
 set +e
 ctest --output-on-failure \
+      --exclude-regex "^test_mrc_benchmarking" \
       --output-junit ${REPORTS_DIR}/report_ctest.xml
 
 CTEST_RESULTS=$?

--- a/ci/scripts/github/test_codecov.sh
+++ b/ci/scripts/github/test_codecov.sh
@@ -43,11 +43,10 @@ cd ${MRC_ROOT}/build
 # Ensure we have a clean slate
 find . -type f  \( -iname "*.gcov" -or -iname "*.gcda" \) -exec rm {} \;
 
+# Exclude test_mrc_benchmarking to work-around #554
 set +e
-# Tests known to be failing
-# Issues:
-# * test_mrc_private - https://github.com/nv-morpheus/MRC/issues/33
 ctest --output-on-failure \
+      --exclude-regex "^test_mrc_benchmarking" \
       --output-junit ${REPORTS_DIR}/report_ctest.xml
 
 CTEST_RESULTS=$?


### PR DESCRIPTION
## Description
* Work-around for #554

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
